### PR TITLE
docs(kwctl): Add instruction to install kwctl with Cargo

### DIFF
--- a/docs/kwctl/README.md
+++ b/docs/kwctl/README.md
@@ -44,7 +44,7 @@ containers.
 ## Install
 
 Built binaries for `Linux x86_64`, `Windows x86_64`, `MacOS x86_64` and `MacOS
-aarch64 (M1)` are available in [GH Releases](https://github.com/kubewarden/kwctl/releases).
+aarch64 (M1)` are available in [GH Releases](github.com/kubewarden/adm-controller/releases) (check the `kwctl-${os}-${arch}.zip` files).
 
 There is also:
 

--- a/docs/kwctl/README.md
+++ b/docs/kwctl/README.md
@@ -50,6 +50,11 @@ There is also:
 
 - Community-created [Homebrew 🍺 formula for kwctl](https://formulae.brew.sh/formula/kwctl)
 - Community-created [AUR 🐧 package](https://aur.archlinux.org/packages/kwctl-bin)
+- Source install with Cargo. You can pull the latest version from main, or chose a specific git tag.
+
+```bash
+cargo install --git https://github.com/kubewarden/adm-controller kwctl [--tag <desired-version>]
+```
 
 ## Usage
 

--- a/docs/kwctl/README.md
+++ b/docs/kwctl/README.md
@@ -44,7 +44,7 @@ containers.
 ## Install
 
 Built binaries for `Linux x86_64`, `Windows x86_64`, `MacOS x86_64` and `MacOS
-aarch64 (M1)` are available in [GH Releases](github.com/kubewarden/adm-controller/releases) (check the `kwctl-${os}-${arch}.zip` files).
+aarch64 (M1)` are available in [GH Releases](https://github.com/kubewarden/adm-controller/releases) (check the `kwctl-${os}-${arch}.zip` files).
 
 There is also:
 


### PR DESCRIPTION
## Description

Updates kwctl docs to include instructions to install from source with Cargo.
Cargo finds the crate in the subdir because it is defined in the [Cargo.toml](https://github.com/kubewarden/adm-controller/blob/main/Cargo.toml) file (under the crates fodler).

Installing from source with Cargo is a convenient and cross-platform way for users to install kwctl.

## Test

Results running this instruction:

```bash
$ cargo install --git https://github.com/kubewarden/adm-controller kwctl
    Updating git repository `https://github.com/kubewarden/adm-controller`
remote: Enumerating objects: 56123, done.
remote: Counting objects: 100% (1091/1091), done.
remote: Compressing objects: 100% (314/314), done.
remote: Total 56123 (delta 960), reused 786 (delta 776), pack-reused 55032 (from 3)
Receiving objects: 100% (56123/56123), 40.63 MiB | 13.21 MiB/s, done.
Resolving deltas: 100% (29141/29141), done.
From github.com:kubewarden/adm-controller
 * [new ref]           HEAD       -> origin/HEAD
  Installing kwctl v1.37.1 (https://github.com/kubewarden/adm-controller#29d3ab9d)
    Updating crates.io index
     Locking 710 packages to latest compatible versions
      Adding generic-array v0.14.7 (available: v0.14.9)
      Adding pem v3.0.6 (available: v4.0.0)
      Adding reqwest v0.12.28 (available: v0.13.4)
      Adding wasmtime v46.0.2 (available: v47.0.3)
      Adding wasmtime-wasi v46.0.2 (available: v47.0.3)
  Downloaded asn1-rs-derive v0.6.0
  ...
     Compiling kwctl v1.37.1 (/home/auyer/.cargo/git/checkouts/adm-controller-bf03130f3e7b8fae/29d3ab9/crates/kwctl)
    Finished `release` profile [optimized] target(s) in 1m 08s
  Installing /home/auyer/.cargo/bin/kwctl
   Installed package `kwctl v1.37.1 (https://github.com/kubewarden/adm-controller#29d3ab9d)` (executable `kwctl`)
   
$ kwctl --version
kwctl 1.37.1

Use the `info` command to display system information.
   ```

### Potential improvement
1. Maybe instead of pulling from HEAD, this could instruct the user to pull a tag.
Example pulling the previous tag: 
```bash
$ cargo install --git https://github.com/kubewarden/adm-controller kwctl --tag v1.37.0
    Updating git repository `https://github.com/kubewarden/adm-controller`
remote: Enumerating objects: 1, done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 1 (from 1)
Unpacking objects: 100% (1/1), 790 bytes | 790.00 KiB/s, done.
From github.com:kubewarden/adm-controller
 * [new tag]           v1.37.0    -> origin/tags/v1.37.0
  Installing kwctl v1.37.0 (https://github.com/kubewarden/adm-controller?tag=v1.37.0#650a9ce8)
  ...
```
Tell me if you want me to make this change.

2. The same file also instructs the users to visit the releases page for the archived repository. 
I wanted to remove this line in this PR too, but  the last version there is the same being distributed in the openSUSE repositories (1.31.0) : https://software.opensuse.org/package/kwctl?search_term=kwctl

> Built binaries for ...  are available in GH Releases -> https://github.com/kubewarden/kwctl/releases

The version built from source is 1.37.1 (as noted in the test section).
I'm not sure if this is intentional or if the new release process has not been established yet. :)

## Checklist

- [X] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
