### PR TITLE
fix(policy-server,controller): Change unique internal identifier for policies

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -41,7 +41,7 @@ jobs:
           arch: ${{ matrix.arch }}
           platform: ${{ matrix.platform }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          namespace: adm-controller
+          namespace: ${{ github.event.repository.name }}
 
   merge:
     runs-on: ubuntu-latest
@@ -74,4 +74,4 @@ jobs:
           tag: ${{ env.TAG_NAME }}
           arch: amd64,arm64
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          namespace: adm-controller
+          namespace: ${{ github.event.repository.name }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -25,6 +25,7 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
     permissions:
+      contents: read # Checkout private forks
       packages: write # Pushing images to ghcr.io
       id-token: write # Signing images with cosign
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -11,7 +11,6 @@ jobs:
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Checkout private forks
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Used to receive a badge. (Upcoming feature)

--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -11,6 +11,7 @@ jobs:
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read # Checkout private forks
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Used to receive a badge. (Upcoming feature)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           arch: ${{ matrix.arch }}
           platform: ${{ matrix.platform }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          namespace: adm-controller
+          namespace: ${{ github.event.repository.name }}
 
   merge-containers:
     name: Merge multi-arch manifests
@@ -109,7 +109,7 @@ jobs:
           tag: ${{ github.ref_name }}
           arch: amd64,arm64
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          namespace: adm-controller
+          namespace: ${{ github.event.repository.name }}
 
   build-kwctl:
     name: Build kwctl binaries
@@ -139,7 +139,7 @@ jobs:
           component: ${{ matrix.component }}
           arch: ${{ matrix.arch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          namespace: adm-controller
+          namespace: ${{ github.event.repository.name }}
 
   release:
     name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
     permissions:
+      contents: read # Checkout private forks
       packages: write # Pushing images to ghcr.io
       id-token: write # Signing images with cosign
     runs-on: ${{ matrix.runner }}

--- a/api/policies/v1/admissionpolicy_types.go
+++ b/api/policies/v1/admissionpolicy_types.go
@@ -154,8 +154,13 @@ func (r *AdmissionPolicy) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// The `.` delimiter guarantees that two distinct policies can never collide:
+// namespaces cannot contain dots, and the kind token (`ap`) is dot-free and
+// unique per policy kind. Policy names may contain dots, but they are the
+// trailing remainder of the string, so the encoding stays unambiguous.
 func (r *AdmissionPolicy) GetUniqueName() string {
-	return "namespaced-" + r.Namespace + "-" + r.Name
+	return "kw.ap." + r.Namespace + "." + r.Name
 }
 
 func (r *AdmissionPolicy) GetContextAwareResources() []ContextAwareResource {

--- a/api/policies/v1/admissionpolicy_webhook_test.go
+++ b/api/policies/v1/admissionpolicy_webhook_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -134,6 +135,19 @@ func TestAdmissionPolicyValidateCreateWithErrors(t *testing.T) {
 	assert.Empty(t, warnings)
 }
 
+func TestAdmissionPolicyValidateCreateRejectsOverlongName(t *testing.T) {
+	validator := admissionPolicyValidator{logger: logr.Discard()}
+	policy := NewAdmissionPolicyFactory().
+		WithName(strings.Repeat("a", 250)).
+		WithNamespace("team").
+		Build()
+
+	warnings, err := validator.ValidateCreate(t.Context(), policy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "characters long")
+	assert.Empty(t, warnings)
+}
+
 func TestAdmissionPolicyValidateUpdate(t *testing.T) {
 	validator := admissionPolicyValidator{logger: logr.Discard()}
 	oldPolicy := NewAdmissionPolicyFactory().Build()
@@ -175,6 +189,28 @@ func TestAdmissionPolicyValidateUpdateWithErrors(t *testing.T) {
 
 	warnings, err = validator.ValidateUpdate(t.Context(), newPolicy, oldPolicy)
 	require.Error(t, err)
+	assert.Empty(t, warnings)
+}
+
+func TestAdmissionPolicyValidateUpdateAllowsPreExistingOverlongName(t *testing.T) {
+	// Name and namespace are immutable, so an overlong policy that somehow
+	// already exists (e.g. created by an older, less strict controller
+	// version) must remain updatable.
+	validator := admissionPolicyValidator{logger: logr.Discard()}
+	overlongName := strings.Repeat("a", 250)
+	oldPolicy := NewAdmissionPolicyFactory().
+		WithName(overlongName).
+		WithNamespace("team").
+		WithMode("monitor").
+		Build()
+	newPolicy := NewAdmissionPolicyFactory().
+		WithName(overlongName).
+		WithNamespace("team").
+		WithMode("protect").
+		Build()
+
+	warnings, err := validator.ValidateUpdate(t.Context(), oldPolicy, newPolicy)
+	require.NoError(t, err)
 	assert.Empty(t, warnings)
 }
 

--- a/api/policies/v1/admissionpolicygroup_types.go
+++ b/api/policies/v1/admissionpolicygroup_types.go
@@ -179,8 +179,13 @@ func (r *AdmissionPolicyGroup) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// The `.` delimiter guarantees that two distinct policies can never collide:
+// namespaces cannot contain dots, and the kind token (`apg`) is dot-free and
+// unique per policy kind. Policy names may contain dots, but they are the
+// trailing remainder of the string, so the encoding stays unambiguous.
 func (r *AdmissionPolicyGroup) GetUniqueName() string {
-	return "namespaced-group-" + r.Namespace + "-" + r.Name
+	return "kw.apg." + r.Namespace + "." + r.Name
 }
 
 func (r *AdmissionPolicyGroup) GetContextAwareResources() []ContextAwareResource {

--- a/api/policies/v1/clusteradmissionpolicy_types.go
+++ b/api/policies/v1/clusteradmissionpolicy_types.go
@@ -212,8 +212,11 @@ func (r *ClusterAdmissionPolicy) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// The `.` delimiter and the dot-free, kind-unique token (`cap`) guarantee
+// that two distinct policies can never collide, regardless of their kind.
 func (r *ClusterAdmissionPolicy) GetUniqueName() string {
-	return "clusterwide-" + r.Name
+	return "kw.cap." + r.Name
 }
 
 func (r *ClusterAdmissionPolicy) GetContextAwareResources() []ContextAwareResource {

--- a/api/policies/v1/clusteradmissionpolicygroup_types.go
+++ b/api/policies/v1/clusteradmissionpolicygroup_types.go
@@ -231,8 +231,11 @@ func (r *ClusterAdmissionPolicyGroup) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// The `.` delimiter and the dot-free, kind-unique token (`capg`) guarantee
+// that two distinct policies can never collide, regardless of their kind.
 func (r *ClusterAdmissionPolicyGroup) GetUniqueName() string {
-	return "clusterwide-group-" + r.Name
+	return "kw.capg." + r.Name
 }
 
 func (r *ClusterAdmissionPolicyGroup) GetContextAwareResources() []ContextAwareResource {

--- a/api/policies/v1/policy_validation.go
+++ b/api/policies/v1/policy_validation.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions"
 	"k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/environment"
+
+	"github.com/kubewarden/adm-controller/internal/constants"
 )
 
 // nonStrictStatelessCELCompiler is a cel Compiler that does not enforce strict cost enforcement.
@@ -85,6 +87,9 @@ func validatePolicyCreate(policy Policy) field.ErrorList {
 	allErrors = append(allErrors, validateRulesField(policy)...)
 	allErrors = append(allErrors, validateMatchConditions(policy.GetMatchConditions(), field.NewPath("spec").Child("matchConditions"))...)
 	allErrors = append(allErrors, validateTimeoutSeconds(policy)...)
+	if err := validateUniqueNameLength(policy); err != nil {
+		allErrors = append(allErrors, err)
+	}
 	return allErrors
 }
 
@@ -102,6 +107,31 @@ func validatePolicyUpdate(oldPolicy, newPolicy Policy) field.ErrorList {
 	}
 
 	return allErrors
+}
+
+// validateUniqueNameLength ensures that the policy's derived unique name,
+// once combined with the suffix used to build the corresponding webhook
+// entry name, does not exceed the Kubernetes DNS1123 subdomain length limit.
+// Name and namespace are immutable, so this is only checked on creation:
+// checking it on update as well would make an already-persisted, overlong
+// policy impossible to modify without providing any additional protection.
+func validateUniqueNameLength(policy Policy) *field.Error {
+	webhookName := policy.GetUniqueName() + constants.WebhookNameSuffix
+	if len(webhookName) <= validation.DNS1123SubdomainMaxLength {
+		return nil
+	}
+
+	maxNameLength := validation.DNS1123SubdomainMaxLength - len(constants.WebhookNameSuffix) - len(policy.GetUniqueName()) + len(policy.GetName())
+
+	return field.Invalid(
+		field.NewPath("metadata").Child("name"),
+		policy.GetName(),
+		fmt.Sprintf(
+			"the policy name combined with its namespace and kind produces an identity that is too long (%d characters, max %d); "+
+				"the name must be at most %d characters long",
+			len(webhookName), validation.DNS1123SubdomainMaxLength, maxNameLength,
+		),
+	)
 }
 
 // Validates the spec.Rules field for non-empty, webhook-valid rules.

--- a/api/policies/v1/policy_validation_test.go
+++ b/api/policies/v1/policy_validation_test.go
@@ -15,13 +15,17 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kubewarden/adm-controller/internal/constants"
 )
 
 func TestSensitiveResourceMatchRule(t *testing.T) {
@@ -651,6 +655,65 @@ func TestValidateTimeoutSeconds(t *testing.T) {
 					require.True(t, found, "expected error containing %q, got %v", expected, errs)
 				}
 			}
+		})
+	}
+}
+
+// TestValidateUniqueNameLength verifies that a policy whose unique name,
+// combined with the webhook entry name suffix, would exceed the Kubernetes
+// DNS1123 subdomain length limit is rejected, for all four policy kinds.
+// A policy at exactly the maximum allowed length must be accepted.
+func TestValidateUniqueNameLength(t *testing.T) {
+	tests := []struct {
+		name        string
+		buildPolicy func(policyName string) Policy
+	}{
+		{
+			name: "AdmissionPolicy",
+			buildPolicy: func(policyName string) Policy {
+				return NewAdmissionPolicyFactory().WithName(policyName).WithNamespace("team").Build()
+			},
+		},
+		{
+			name: "AdmissionPolicyGroup",
+			buildPolicy: func(policyName string) Policy {
+				return NewAdmissionPolicyGroupFactory().WithName(policyName).WithNamespace("team").Build()
+			},
+		},
+		{
+			name: "ClusterAdmissionPolicy",
+			buildPolicy: func(policyName string) Policy {
+				return NewClusterAdmissionPolicyFactory().WithName(policyName).Build()
+			},
+		},
+		{
+			name: "ClusterAdmissionPolicyGroup",
+			buildPolicy: func(policyName string) Policy {
+				return NewClusterAdmissionPolicyGroupFactory().WithName(policyName).Build()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// The unique name is built as some fixed overhead (kind token,
+			// optional namespace, dots) plus the policy name verbatim. Probe
+			// that overhead with a throwaway 1-character name, then derive
+			// the exact name length at which the webhook entry name reaches
+			// the DNS1123 subdomain length limit.
+			probe := tc.buildPolicy("x")
+			overhead := len(probe.GetUniqueName()) - len(probe.GetName())
+			maxNameLength := validation.DNS1123SubdomainMaxLength - len(constants.WebhookNameSuffix) - overhead
+			require.Positive(t, maxNameLength, "test setup error: computed a non-positive max name length")
+
+			atLimit := tc.buildPolicy(strings.Repeat("a", maxNameLength))
+			require.Nil(t, validateUniqueNameLength(atLimit),
+				"a policy name at the maximum allowed length should be accepted")
+
+			overLimit := tc.buildPolicy(strings.Repeat("a", maxNameLength+1))
+			err := validateUniqueNameLength(overLimit)
+			require.NotNil(t, err, "a policy name one character over the limit should be rejected")
+			require.Contains(t, err.Error(), fmt.Sprintf("at most %d characters long", maxNameLength))
 		})
 	}
 }

--- a/api/policies/v1/unique_name_test.go
+++ b/api/policies/v1/unique_name_test.go
@@ -1,0 +1,91 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The unique name is used as the name of cluster-scoped webhook
+// configurations, as the policy-server admission path and as the key of the
+// policy-server configuration entries. Hence the encoding must be injective:
+// two distinct policies (of any kind) must never produce the same unique
+// name. The legacy `-`-delimited encoding was ambiguous and allowed a tenant
+// to hijack the admission traffic of another namespace (security fix).
+
+func TestAdmissionPolicyUniqueNameFormat(t *testing.T) {
+	policy := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	assert.Equal(t, "kw.ap.tenant-prod.baseline", policy.GetUniqueName())
+
+	group := AdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	assert.Equal(t, "kw.apg.tenant-prod.baseline", group.GetUniqueName())
+
+	clusterPolicy := ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "baseline"},
+	}
+	assert.Equal(t, "kw.cap.baseline", clusterPolicy.GetUniqueName())
+
+	clusterGroup := ClusterAdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "baseline"},
+	}
+	assert.Equal(t, "kw.capg.baseline", clusterGroup.GetUniqueName())
+}
+
+// Regression test: `tenant-prod/baseline` and `tenant/prod-baseline` used to
+// collide on `namespaced-tenant-prod-baseline`. The namespace cannot contain
+// dots, so the `.` delimiter keeps the two identities distinct.
+func TestAdmissionPolicyUniqueNameNoCollisionAcrossNamespaces(t *testing.T) {
+	victim := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	attacker := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "prod-baseline"},
+	}
+
+	assert.NotEqual(t, victim.GetUniqueName(), attacker.GetUniqueName())
+}
+
+// Regression test: an AdmissionPolicy in namespace `group-x` used to collide
+// with an AdmissionPolicyGroup in namespace `x` bearing the same name
+// (`namespaced-group-x-<name>`). The kind token is dot-free and unique per
+// kind, so identities of different kinds can never collide.
+func TestUniqueNameNoCollisionAcrossKinds(t *testing.T) {
+	policy := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "group-x", Name: "y"},
+	}
+	group := AdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "x", Name: "y"},
+	}
+	assert.NotEqual(t, policy.GetUniqueName(), group.GetUniqueName())
+
+	clusterPolicy := ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "group-y"},
+	}
+	clusterGroup := ClusterAdmissionPolicyGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "y"},
+	}
+	assert.NotEqual(t, clusterPolicy.GetUniqueName(), clusterGroup.GetUniqueName())
+}
+
+// Policy names may contain dots: the namespace and the kind token are the
+// only segments used to decode the identity, so dotted policy names cannot
+// craft an identity belonging to another namespace.
+func TestUniqueNameNoCollisionWithDottedPolicyNames(t *testing.T) {
+	dottedName := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "prod.baseline"},
+	}
+	victim := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	otherVictim := AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "baseline"},
+	}
+
+	assert.NotEqual(t, victim.GetUniqueName(), dottedName.GetUniqueName())
+	assert.NotEqual(t, otherVictim.GetUniqueName(), dottedName.GetUniqueName())
+}

--- a/api/policies/v1alpha2/admissionpolicy_types.go
+++ b/api/policies/v1alpha2/admissionpolicy_types.go
@@ -133,6 +133,8 @@ func (r *AdmissionPolicy) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// See the policies/v1 implementation for details about the encoding.
 func (r *AdmissionPolicy) GetUniqueName() string {
-	return "namespaced-" + r.Namespace + "-" + r.Name
+	return "kw.ap." + r.Namespace + "." + r.Name
 }

--- a/api/policies/v1alpha2/clusteradmissionpolicy_types.go
+++ b/api/policies/v1alpha2/clusteradmissionpolicy_types.go
@@ -168,6 +168,8 @@ func (r *ClusterAdmissionPolicy) GetPolicyServer() string {
 	return r.Spec.PolicyServer
 }
 
+// GetUniqueName returns the cluster-wide unique identity of the policy.
+// See the policies/v1 implementation for details about the encoding.
 func (r *ClusterAdmissionPolicy) GetUniqueName() string {
-	return "clusterwide-" + r.Name
+	return "kw.cap." + r.Name
 }

--- a/crates/policy-evaluator/src/runtimes/rego/runtime.rs
+++ b/crates/policy-evaluator/src/runtimes/rego/runtime.rs
@@ -87,19 +87,26 @@ impl Runtime<'_> {
                         struct Violation {
                             msg: Option<String>,
                         }
-                        #[derive(Debug, Default, Deserialize)]
+                        #[derive(Debug, Deserialize)]
                         struct Violations {
                             result: Vec<Violation>,
                         }
 
-                        let violations: Violations = evaluation_result
+                        let violations: Violations = match evaluation_result
                             .get(0)
-                            .ok_or_else(|| RegoRuntimeError::InvalidResponse)
+                            .ok_or(RegoRuntimeError::InvalidResponse)
                             .and_then(|response| {
                                 serde_json::from_value(response.clone())
                                     .map_err(RegoRuntimeError::InvalidResponseWithError)
-                            })
-                            .unwrap_or_default();
+                            }) {
+                            Ok(violations) => violations,
+                            Err(err) => {
+                                return AdmissionResponse::reject_internal_server_error(
+                                    uid.to_string(),
+                                    err.to_string(),
+                                );
+                            }
+                        };
 
                         if violations.result.is_empty() {
                             AdmissionResponse {

--- a/crates/policy-fetcher/src/verify/config.rs
+++ b/crates/policy-fetcher/src/verify/config.rs
@@ -205,6 +205,37 @@ pub fn build_latest_verification_config(
             "config is missing signatures in both allOf and anyOff list".to_owned(),
         ));
     }
+
+    // If the user set the allOf or anyOf key, the list must have some value. Empty list is not
+    // allowed. This rule should be apply to both fields.
+    if let Some(ref all_of) = config.all_of
+        && all_of.is_empty()
+    {
+        return Err(VerifyError::InvalidVerifyFileError(
+            "config's allOf list is empty".to_owned(),
+        ));
+    }
+
+    if let Some(ref any_of) = config.any_of {
+        if any_of.signatures.is_empty() {
+            return Err(VerifyError::InvalidVerifyFileError(
+                "config's anyOf.signatures list is empty".to_owned(),
+            ));
+        }
+        if any_of.minimum_matches == 0 {
+            return Err(VerifyError::InvalidVerifyFileError(
+                "config's anyOf.minimumMatches must be greater than 0".to_owned(),
+            ));
+        }
+        if usize::from(any_of.minimum_matches) > any_of.signatures.len() {
+            return Err(VerifyError::InvalidVerifyFileError(format!(
+                "config's anyOf.minimumMatches ({}) cannot be greater than the number of signatures ({})",
+                any_of.minimum_matches,
+                any_of.signatures.len()
+            )));
+        }
+    }
+
     Ok(config)
 }
 
@@ -284,6 +315,84 @@ mod tests {
                 _ => panic!("not the expected versioned config"),
             },
             _ => panic!("got an invalid config"),
+        }
+    }
+
+    #[test]
+    fn test_reject_empty_all_of() {
+        let config = r#"---
+    apiVersion: v1
+
+    allOf: []
+    "#;
+        match build_latest_verification_config(config) {
+            Err(VerifyError::InvalidVerifyFileError(msg)) => {
+                assert_eq!(msg, "config's allOf list is empty")
+            }
+            _ => panic!("expected an error"),
+        }
+    }
+
+    #[test]
+    fn test_reject_empty_any_of_signatures() {
+        let config = r#"---
+    apiVersion: v1
+
+    anyOf:
+      signatures: []
+    "#;
+        match build_latest_verification_config(config) {
+            Err(VerifyError::InvalidVerifyFileError(msg)) => {
+                assert_eq!(msg, "config's anyOf.signatures list is empty")
+            }
+            _ => panic!("expected an error"),
+        }
+    }
+
+    #[test]
+    fn test_reject_zero_minimum_matches() {
+        let config = r#"---
+    apiVersion: v1
+
+    anyOf:
+      minimumMatches: 0
+      signatures:
+        - kind: genericIssuer
+          issuer: https://token.actions.githubusercontent.com
+          subject:
+             equal: https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
+    "#;
+        match build_latest_verification_config(config) {
+            Err(VerifyError::InvalidVerifyFileError(msg)) => {
+                assert_eq!(msg, "config's anyOf.minimumMatches must be greater than 0")
+            }
+            _ => panic!("expected an error"),
+        }
+    }
+
+    #[test]
+    fn test_reject_minimum_matches_exceeds_signatures() {
+        let config = r#"---
+    apiVersion: v1
+
+    anyOf:
+      minimumMatches: 3
+      signatures:
+        - kind: genericIssuer
+          issuer: https://token.actions.githubusercontent.com
+          subject:
+             equal: https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
+        - kind: genericIssuer
+          issuer: https://token.actions.githubusercontent.com
+          subject:
+             urlPrefix: https://github.com/kubewarden
+    "#;
+        match build_latest_verification_config(config) {
+            Err(VerifyError::InvalidVerifyFileError(msg)) => assert_eq!(
+                msg,
+                "config's anyOf.minimumMatches (3) cannot be greater than the number of signatures (2)"
+            ),
+            _ => panic!("expected an error"),
         }
     }
 

--- a/crates/policy-fetcher/src/verify/config.rs
+++ b/crates/policy-fetcher/src/verify/config.rs
@@ -241,6 +241,8 @@ pub fn build_latest_verification_config(
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -252,9 +254,9 @@ mod tests {
         assert!(vc.is_err());
     }
 
-    #[test]
-    fn test_deserialize_on_missing_signature() {
-        let config = r#"---
+    #[rstest]
+    #[case::missing_signature(
+        r#"---
     apiVersion: v1
 
     allOf:
@@ -263,95 +265,38 @@ mod tests {
         # missing subject
         #subject:
         #   urlPrefix: https://github.com/kubewarden/
-    "#;
-        match build_latest_verification_config(config) {
-            Err(VerifyError::InvalidVerifyFileError(msg)) => assert_eq!(
-                msg,
-                "Not a valid configuration file: missing field `subject`"
-            ),
-            _ => panic!("expected an error"),
-        }
-    }
-
-    #[test]
-    fn test_deserialize() {
-        let config = r#"---
-    apiVersion: v1
-
-    allOf:
-      - kind: genericIssuer
-        issuer: https://token.actions.githubusercontent.com
-        subject:
-           equal: https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
-      - kind: genericIssuer
-        issuer: https://token.actions.githubusercontent.com
-        subject:
-           urlPrefix: https://github.com/kubewarden
-    "#;
-
-        let vc: VerificationConfig = serde_yaml::from_str(config).unwrap();
-        let signatures: Vec<Signature> = vec![
-            Signature::GenericIssuer {
-                    issuer: "https://token.actions.githubusercontent.com".to_string(),
-                    subject: Subject::Equal("https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main".to_string()),
-                    annotations: None
-                },
-            Signature::GenericIssuer {
-                issuer: "https://token.actions.githubusercontent.com".to_string(),
-                subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
-                annotations: None,
-            }
-        ];
-
-        match vc {
-            VerificationConfig::Versioned(versioned) => match versioned {
-                VersionedVerificationConfig::V1(v1) => {
-                    let expected = VerificationConfigV1 {
-                        all_of: Some(signatures),
-                        any_of: None,
-                    };
-                    assert_eq!(v1, expected);
-                }
-                _ => panic!("not the expected versioned config"),
-            },
-            _ => panic!("got an invalid config"),
-        }
-    }
-
-    #[test]
-    fn test_reject_empty_all_of() {
-        let config = r#"---
+    "#,
+        "Not a valid configuration file: missing field `subject`"
+    )]
+    #[case::empty_all_of(
+        r#"---
     apiVersion: v1
 
     allOf: []
-    "#;
-        match build_latest_verification_config(config) {
-            Err(VerifyError::InvalidVerifyFileError(msg)) => {
-                assert_eq!(msg, "config's allOf list is empty")
-            }
-            _ => panic!("expected an error"),
-        }
-    }
-
-    #[test]
-    fn test_reject_empty_any_of_signatures() {
-        let config = r#"---
+    "#,
+        "config's allOf list is empty"
+    )]
+    #[case::empty_any_of_signatures(
+        r#"---
     apiVersion: v1
 
     anyOf:
       signatures: []
-    "#;
-        match build_latest_verification_config(config) {
-            Err(VerifyError::InvalidVerifyFileError(msg)) => {
-                assert_eq!(msg, "config's anyOf.signatures list is empty")
-            }
-            _ => panic!("expected an error"),
-        }
-    }
+    "#,
+        "config's anyOf.signatures list is empty"
+    )]
+    #[case::empty_all_of_and_any_of_signatures(
+        r#"---
+    apiVersion: v1
 
-    #[test]
-    fn test_reject_zero_minimum_matches() {
-        let config = r#"---
+    allOf: []
+    anyOf:
+      signatures: []
+    "#,
+        "config's allOf list is empty"
+    )]
+    #[case::zero_minimum_matches(
+        r#"---
     apiVersion: v1
 
     anyOf:
@@ -361,18 +306,11 @@ mod tests {
           issuer: https://token.actions.githubusercontent.com
           subject:
              equal: https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
-    "#;
-        match build_latest_verification_config(config) {
-            Err(VerifyError::InvalidVerifyFileError(msg)) => {
-                assert_eq!(msg, "config's anyOf.minimumMatches must be greater than 0")
-            }
-            _ => panic!("expected an error"),
-        }
-    }
-
-    #[test]
-    fn test_reject_minimum_matches_exceeds_signatures() {
-        let config = r#"---
+    "#,
+        "config's anyOf.minimumMatches must be greater than 0"
+    )]
+    #[case::minimum_matches_exceeds_signatures(
+        r#"---
     apiVersion: v1
 
     anyOf:
@@ -386,19 +324,51 @@ mod tests {
           issuer: https://token.actions.githubusercontent.com
           subject:
              urlPrefix: https://github.com/kubewarden
-    "#;
-        match build_latest_verification_config(config) {
-            Err(VerifyError::InvalidVerifyFileError(msg)) => assert_eq!(
-                msg,
-                "config's anyOf.minimumMatches (3) cannot be greater than the number of signatures (2)"
-            ),
-            _ => panic!("expected an error"),
-        }
+    "#,
+        "config's anyOf.minimumMatches (3) cannot be greater than the number of signatures (2)"
+    )]
+    fn test_build_latest_verification_config_rejects_invalid_configs(
+        #[case] config: &str,
+        #[case] expected_msg: &str,
+    ) {
+        let err = build_latest_verification_config(config).expect_err("expected an error");
+        assert!(
+            matches!(err, VerifyError::InvalidVerifyFileError(_)),
+            "unexpected error variant: {err:?}"
+        );
+        assert_eq!(err.to_string(), expected_msg);
     }
 
-    #[test]
-    fn test_sanitize_url_prefix() {
-        let config = r#"---
+    #[rstest]
+    #[case::equal_and_url_prefix_subjects(
+        r#"---
+    apiVersion: v1
+
+    allOf:
+      - kind: genericIssuer
+        issuer: https://token.actions.githubusercontent.com
+        subject:
+           equal: https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main
+      - kind: genericIssuer
+        issuer: https://token.actions.githubusercontent.com
+        subject:
+           urlPrefix: https://github.com/kubewarden
+    "#,
+        vec![
+            Signature::GenericIssuer {
+                issuer: "https://token.actions.githubusercontent.com".to_string(),
+                subject: Subject::Equal("https://github.com/kubewarden/policy-secure-pod-images/.github/workflows/release.yml@refs/heads/main".to_string()),
+                annotations: None,
+            },
+            Signature::GenericIssuer {
+                issuer: "https://token.actions.githubusercontent.com".to_string(),
+                subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
+                annotations: None,
+            },
+        ]
+    )]
+    #[case::url_prefix_sanitized_with_and_without_trailing_slash(
+        r#"---
     apiVersion: v1
 
     allOf:
@@ -410,9 +380,8 @@ mod tests {
         issuer: https://yourdomain.com/oauth2
         subject:
            urlPrefix: https://github.com/kubewarden/ # should deserialize path to kubewarden/
-    "#;
-        let vc: VerificationConfig = serde_yaml::from_str(config).unwrap();
-        let signatures: Vec<Signature> = vec![
+    "#,
+        vec![
             Signature::GenericIssuer {
                 issuer: "https://token.actions.githubusercontent.com".to_string(),
                 subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
@@ -423,20 +392,25 @@ mod tests {
                 subject: Subject::UrlPrefix(Url::parse("https://github.com/kubewarden/").unwrap()),
                 annotations: None,
             },
-        ];
+        ]
+    )]
+    fn test_deserialize_all_of_signatures(
+        #[case] config: &str,
+        #[case] expected_signatures: Vec<Signature>,
+    ) {
+        let vc: VerificationConfig =
+            serde_yaml::from_str(config).expect("failed to deserialize config");
 
-        match vc {
-            VerificationConfig::Versioned(versioned) => match versioned {
-                VersionedVerificationConfig::V1(v1) => {
-                    let expected = VerificationConfigV1 {
-                        all_of: Some(signatures),
-                        any_of: None,
-                    };
-                    assert_eq!(v1, expected);
-                }
-                _ => panic!("not the expected versioned config"),
-            },
-            _ => panic!("got an invalid config"),
+        let v1 = match vc {
+            VerificationConfig::Versioned(VersionedVerificationConfig::V1(v1)) => Some(v1),
+            _ => None,
         }
+        .expect("expected a V1 versioned config");
+
+        let expected = VerificationConfigV1 {
+            all_of: Some(expected_signatures),
+            any_of: None,
+        };
+        assert_eq!(v1, expected);
     }
 }

--- a/e2e/admissionpolicy_identity_test.go
+++ b/e2e/admissionpolicy_identity_test.go
@@ -1,0 +1,277 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+const (
+	victimPolicyKey   contextKey = "victimPolicy"
+	attackerPolicyKey contextKey = "attackerPolicy"
+)
+
+// legacyUniqueName returns the ambiguous unique name used by previous
+// versions of the controller. It is used to verify the migration away from
+// it: the cleanup of leftover webhook configurations and the transitional
+// dual-key policy-server configuration.
+func legacyUniqueName(policy *policiesv1.AdmissionPolicy) string {
+	return "namespaced-" + policy.GetNamespace() + "-" + policy.GetName()
+}
+
+// getPolicyServerPoliciesEntry returns the parsed `policies.yml` entry of the
+// given PolicyServer's ConfigMap.
+func getPolicyServerPoliciesEntry(ctx context.Context, cfg *envconf.Config, policyServerName string) (map[string]json.RawMessage, error) {
+	configMap := &corev1.ConfigMap{}
+	err := cfg.Client().Resources(namespace).Get(ctx, "policy-server-"+policyServerName, namespace, configMap)
+	if err != nil {
+		return nil, err
+	}
+
+	policies := map[string]json.RawMessage{}
+	err = json.Unmarshal([]byte(configMap.Data[constants.PolicyServerConfigPoliciesEntry]), &policies)
+	if err != nil {
+		return nil, err
+	}
+	return policies, nil
+}
+
+// TestPolicyIdentity covers the security fix for the ambiguous policy unique
+// names (`namespaced-<namespace>-<name>`): distinct policies used to collide
+// on the same webhook configuration, admission path and policy-server
+// configuration entry, allowing a tenant to have its module evaluate the
+// admission traffic of another namespace.
+func TestPolicyIdentity(t *testing.T) {
+	victimNamespace := "tenant-prod"
+	attackerNamespace := "tenant"
+
+	// Regression test for the identity collision: `tenant-prod/baseline` and
+	// `tenant/prod-baseline` used to collide on the same identity,
+	// `namespaced-tenant-prod-baseline`.
+	collisionFeature := features.New("Colliding policy identities").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Create namespaces
+			err := createNamespaceWithRetry(ctx, cfg, victimNamespace)
+			require.NoError(t, err)
+			err = createNamespaceWithRetry(ctx, cfg, attackerNamespace)
+			require.NoError(t, err)
+
+			// Add scheme
+			err = policiesv1.AddToScheme(cfg.Client().Resources().GetScheme())
+			require.NoError(t, err)
+
+			// Create PolicyServer and wait for it to be ready
+			policyServerName := policiesv1.NewPolicyServerFactory().Build().Name
+			policyServer := policiesv1.NewPolicyServerFactory().
+				WithName(policyServerName).
+				Build()
+			err = createPolicyServerAndWaitForItsService(ctx, cfg, policyServer)
+			require.NoError(t, err)
+
+			ctx = context.WithValue(ctx, policyServerNameKey, policyServerName)
+
+			// Create two AdmissionPolicies bound to the same PolicyServer,
+			// whose legacy unique names collide.
+			victimPolicy := policiesv1.NewAdmissionPolicyFactory().
+				WithName("baseline").
+				WithNamespace(victimNamespace).
+				WithPolicyServer(policyServerName).
+				Build()
+			err = cfg.Client().Resources().Create(ctx, victimPolicy)
+			require.NoError(t, err)
+
+			attackerPolicy := policiesv1.NewAdmissionPolicyFactory().
+				WithName("prod-baseline").
+				WithNamespace(attackerNamespace).
+				WithPolicyServer(policyServerName).
+				Build()
+			err = cfg.Client().Resources().Create(ctx, attackerPolicy)
+			require.NoError(t, err)
+
+			require.Equal(t, legacyUniqueName(victimPolicy), legacyUniqueName(attackerPolicy),
+				"test setup error: the two policies are expected to collide on their legacy unique names")
+
+			ctx = context.WithValue(ctx, victimPolicyKey, victimPolicy)
+			ctx = context.WithValue(ctx, attackerPolicyKey, attackerPolicy)
+
+			return ctx
+		}).
+		Assess("both policies should become active", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			victimPolicy := ctx.Value(victimPolicyKey).(*policiesv1.AdmissionPolicy)
+			attackerPolicy := ctx.Value(attackerPolicyKey).(*policiesv1.AdmissionPolicy)
+
+			err := waitForAdmissionPolicyActive(cfg, victimPolicy.GetName(), victimPolicy.GetNamespace())
+			require.NoError(t, err, "the victim policy should transition to active status")
+
+			err = waitForAdmissionPolicyActive(cfg, attackerPolicy.GetName(), attackerPolicy.GetNamespace())
+			require.NoError(t, err, "the attacker policy should transition to active status")
+
+			return ctx
+		}).
+		Assess("each policy should get its own ValidatingWebhookConfiguration and admission path", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			victimPolicy := ctx.Value(victimPolicyKey).(*policiesv1.AdmissionPolicy)
+			attackerPolicy := ctx.Value(attackerPolicyKey).(*policiesv1.AdmissionPolicy)
+
+			require.NotEqual(t, victimPolicy.GetUniqueName(), attackerPolicy.GetUniqueName(),
+				"the two policies must have distinct unique names")
+
+			for _, policy := range []*policiesv1.AdmissionPolicy{victimPolicy, attackerPolicy} {
+				webhookName := policy.GetUniqueName()
+				expectedPath := "/validate/" + webhookName
+
+				webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: webhookName},
+				}
+				err := wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(webhook, func(object k8s.Object) bool {
+					w := object.(*admissionregistrationv1.ValidatingWebhookConfiguration)
+
+					if !verifyWebhookMetadata(w.Labels, w.Annotations, policy.GetName(), policy.GetNamespace()) {
+						return false
+					}
+					if len(w.Webhooks) != 1 {
+						return false
+					}
+					if w.Webhooks[0].ClientConfig.Service.Path == nil {
+						return false
+					}
+
+					return *w.Webhooks[0].ClientConfig.Service.Path == expectedPath
+				}), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+				require.NoErrorf(t, err,
+					"policy %s/%s should get its own ValidatingWebhookConfiguration %q routing to %q",
+					policy.GetNamespace(), policy.GetName(), webhookName, expectedPath)
+			}
+
+			return ctx
+		}).
+		Assess("the PolicyServer configuration should serve both policies but not the contended legacy identity", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policyServerName := ctx.Value(policyServerNameKey).(string)
+			victimPolicy := ctx.Value(victimPolicyKey).(*policiesv1.AdmissionPolicy)
+			attackerPolicy := ctx.Value(attackerPolicyKey).(*policiesv1.AdmissionPolicy)
+
+			policies, err := getPolicyServerPoliciesEntry(ctx, cfg, policyServerName)
+			require.NoError(t, err)
+
+			require.Contains(t, policies, victimPolicy.GetUniqueName())
+			require.Contains(t, policies, attackerPolicy.GetUniqueName())
+			// The legacy identity is contended between the two policies:
+			// serving one of them under it would allow its module to evaluate
+			// admission requests meant for the other.
+			require.NotContains(t, policies, legacyUniqueName(victimPolicy),
+				"the contended legacy identity should not be served")
+
+			return ctx
+		}).Feature()
+
+	// Migration test: webhook configurations created by previous versions of
+	// the controller with the legacy unique names must be cleaned up, and the
+	// policy-server configuration must serve the legacy admission paths until
+	// then (transitional dual keys).
+	migrationNamespace := "legacy-migration-test"
+	migrationFeature := features.New("Legacy unique name migration").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Create namespace
+			err := createNamespaceWithRetry(ctx, cfg, migrationNamespace)
+			require.NoError(t, err)
+
+			// Add scheme
+			err = policiesv1.AddToScheme(cfg.Client().Resources().GetScheme())
+			require.NoError(t, err)
+
+			// Create PolicyServer and wait for it to be ready
+			policyServerName := policiesv1.NewPolicyServerFactory().Build().Name
+			policyServer := policiesv1.NewPolicyServerFactory().
+				WithName(policyServerName).
+				Build()
+			err = createPolicyServerAndWaitForItsService(ctx, cfg, policyServer)
+			require.NoError(t, err)
+
+			ctx = context.WithValue(ctx, policyServerNameKey, policyServerName)
+
+			// Create AdmissionPolicy
+			policyName := policiesv1.NewAdmissionPolicyFactory().Build().Name
+			policy := policiesv1.NewAdmissionPolicyFactory().
+				WithName(policyName).
+				WithNamespace(migrationNamespace).
+				WithPolicyServer(policyServerName).
+				Build()
+			err = cfg.Client().Resources().Create(ctx, policy)
+			require.NoError(t, err)
+
+			ctx = context.WithValue(ctx, policyKey, policy)
+
+			return ctx
+		}).
+		Assess("the PolicyServer configuration should serve the policy under both the new and the legacy identity", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policyServerName := ctx.Value(policyServerNameKey).(string)
+			policy := ctx.Value(policyKey).(*policiesv1.AdmissionPolicy)
+
+			err := waitForAdmissionPolicyActive(cfg, policy.GetName(), policy.GetNamespace())
+			require.NoError(t, err, "policy should transition to active status")
+
+			policies, err := getPolicyServerPoliciesEntry(ctx, cfg, policyServerName)
+			require.NoError(t, err)
+
+			require.Contains(t, policies, policy.GetUniqueName())
+			require.Contains(t, policies, legacyUniqueName(policy),
+				"the legacy admission path should be served during the migration window")
+			require.JSONEq(t,
+				string(policies[policy.GetUniqueName()]),
+				string(policies[legacyUniqueName(policy)]),
+				"the legacy identity should serve the very same policy configuration")
+
+			return ctx
+		}).
+		Assess("a webhook configuration left behind by a previous controller version should be deleted", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			policy := ctx.Value(policyKey).(*policiesv1.AdmissionPolicy)
+			legacyWebhookName := legacyUniqueName(policy)
+
+			// Simulate the leftover webhook configuration created by a
+			// previous version of the controller. Its annotations point back
+			// to the policy: the controller's webhook configuration watch
+			// will enqueue the policy reconciliation, no manual trigger is
+			// needed.
+			legacyWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: legacyWebhookName,
+					Labels: map[string]string{
+						constants.PartOfLabelKey: constants.PartOfLabelValue,
+					},
+					Annotations: map[string]string{
+						constants.WebhookConfigurationPolicyNameAnnotationKey:      policy.GetName(),
+						constants.WebhookConfigurationPolicyNamespaceAnnotationKey: policy.GetNamespace(),
+					},
+				},
+			}
+			err := cfg.Client().Resources().Create(ctx, legacyWebhook)
+			require.NoError(t, err)
+
+			// Wait for the controller to clean it up
+			err = wait.For(conditions.New(cfg.Client().Resources()).ResourceDeleted(
+				&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: legacyWebhookName}},
+			), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+			require.NoError(t, err, "the legacy ValidatingWebhookConfiguration should be deleted by the controller")
+
+			// The webhook configuration with the new name must still be there
+			webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			err = cfg.Client().Resources().Get(ctx, policy.GetUniqueName(), "", webhook)
+			require.NoError(t, err, "the webhook configuration with the new name should still exist")
+
+			return ctx
+		}).Feature()
+
+	testenv.Test(t, collisionFeature, migrationFeature)
+}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -71,6 +72,18 @@ func createPolicyServerAndWaitForItsService(ctx context.Context, cfg *envconf.Co
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace}},
 		appsv1.DeploymentAvailable,
 		corev1.ConditionTrue,
+	), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
+}
+
+// waitForAdmissionPolicyActive waits until the given AdmissionPolicy
+// transitions to the active status.
+func waitForAdmissionPolicyActive(cfg *envconf.Config, policyName, policyNamespace string) error {
+	return wait.For(conditions.New(cfg.Client().Resources()).ResourceMatch(
+		&policiesv1.AdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: policyNamespace}},
+		func(object k8s.Object) bool {
+			p := object.(*policiesv1.AdmissionPolicy)
+			return p.Status.PolicyStatus == policiesv1.PolicyStatusActive
+		},
 	), wait.WithTimeout(testTimeout), wait.WithInterval(testPollInterval))
 }
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,4 +1,3 @@
-//nolint:cyclop // This is the e2e test main file, some complexity is expected here.
 package e2e
 
 import (

--- a/internal/audit-scanner/policies/client_test.go
+++ b/internal/audit-scanner/policies/client_test.go
@@ -273,15 +273,15 @@ func TestGetPoliciesByNamespace(t *testing.T) {
 			}: {
 				{
 					Policy:       clusterAdmissionPolicy1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-clusterAdmissionPolicy1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.cap.clusterAdmissionPolicy1"},
 				},
 				{
 					Policy:       admissionPolicy1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/namespaced-test-admissionPolicy1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.ap.test.admissionPolicy1"},
 				},
 				{
 					Policy:       admissionPolicyGroup1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/namespaced-group-test-admissionPolicyGroup1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.apg.test.admissionPolicyGroup1"},
 				},
 			},
 			{
@@ -291,15 +291,15 @@ func TestGetPoliciesByNamespace(t *testing.T) {
 			}: {
 				{
 					Policy:       clusterAdmissionPolicy1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-clusterAdmissionPolicy1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.cap.clusterAdmissionPolicy1"},
 				},
 				{
 					Policy:       clusterAdmissionPolicyGroup1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-group-clusterAdmissionPolicyGroup1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.capg.clusterAdmissionPolicyGroup1"},
 				},
 				{
 					Policy:       admissionPolicy1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/namespaced-test-admissionPolicy1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.ap.test.admissionPolicy1"},
 				},
 			},
 		},
@@ -483,19 +483,19 @@ func TestGetClusterWidePolicies(t *testing.T) {
 			}: {
 				{
 					Policy:       clusterAdmissionPolicy1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-clusterAdmissionPolicy1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.cap.clusterAdmissionPolicy1"},
 				},
 				{
 					Policy:       clusterAdmissionPolicy2,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-clusterAdmissionPolicy2"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.cap.clusterAdmissionPolicy2"},
 				},
 				{
 					Policy:       clusterAdmissionPolicy3,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-clusterAdmissionPolicy3"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.cap.clusterAdmissionPolicy3"},
 				},
 				{
 					Policy:       clusterAdmissionPolicyGroup1,
-					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/clusterwide-group-clusterAdmissionPolicyGroup1"},
+					PolicyServer: &url.URL{Scheme: "https", Host: "policy-server-default.kubewarden.svc:443", Path: "/audit/kw.capg.clusterAdmissionPolicyGroup1"},
 				},
 			},
 		},

--- a/internal/audit-scanner/report/policyreports_test.go
+++ b/internal/audit-scanner/report/policyreports_test.go
@@ -208,7 +208,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored: false,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "clusterwide-policy-name",
+				Policy:          "kw.cap.policy-name",
 				Severity:        severityLow,
 				Result:          statusPass,
 				Timestamp:       now,
@@ -250,7 +250,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored: false,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "namespaced-policy-namespace-policy-name",
+				Policy:          "kw.ap.policy-namespace.policy-name",
 				Severity:        severityCritical,
 				Result:          statusFail,
 				Timestamp:       now,
@@ -297,7 +297,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored: true,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "namespaced-policy-namespace-policy-name",
+				Policy:          "kw.ap.policy-namespace.policy-name",
 				Severity:        severityInfo,
 				Result:          statusError,
 				Timestamp:       now,

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -91,6 +91,13 @@ const (
 	WebhookConfigurationPolicyNameAnnotationKey      = "kubewardenPolicyName"
 	WebhookConfigurationPolicyNamespaceAnnotationKey = "kubewardenPolicyNamespace"
 
+	// WebhookNameSuffix is appended to a policy's unique name to build the
+	// name of the individual webhook entry inside a Mutating/Validating
+	// WebhookConfiguration. The resulting string cannot exceed the
+	// DNS1123Subdomain length limit, which bounds how long a policy's
+	// unique name is allowed to be.
+	WebhookNameSuffix = ".kubewarden.admission"
+
 	NamespacePolicyScope = "namespace"
 	ClusterPolicyScope   = "cluster"
 

--- a/internal/controller/defaults_applier.go
+++ b/internal/controller/defaults_applier.go
@@ -249,7 +249,9 @@ func (r *DefaultsApplierReconciler) cleanupStale(ctx context.Context, desired se
 
 			if !desired.Has(rk) {
 				r.Log.Info("Deleting stale managed resource", "resource", rk)
-				if deleteErr := r.Delete(ctx, item); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				itemUID := item.GetUID()
+				deleteErr := r.Delete(ctx, item, client.Preconditions{UID: &itemUID})
+				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) && !apierrors.IsConflict(deleteErr) {
 					return fmt.Errorf("failed to delete stale resource %s: %w", rk, deleteErr)
 				}
 			}

--- a/internal/controller/legacy_policy_migration.go
+++ b/internal/controller/legacy_policy_migration.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+)
+
+// This file contains temporary migration code that takes care of the rename
+// of the policies' unique names, which happened to fix GHSA advisory about
+// ambiguous policy identities: the legacy `namespaced-<ns>-<name>` encoding
+// was ambiguous (`-` is both the delimiter and a legal character inside of
+// namespace and policy names), allowing two distinct policies to collide on
+// the same webhook configuration, admission path and PolicyServer
+// configuration entry.
+//
+// The Kubewarden upgrade path does not allow jumping versions, hence this
+// code can be safely removed after a few releases, together with the
+// legacy entries written by `buildPoliciesMap`.
+
+// legacyPolicyUniqueName returns the unique name a policy had before the
+// unambiguous `kw.<kind-token>.` encoding was introduced. It returns an empty
+// string for unknown policy types.
+func legacyPolicyUniqueName(policy policiesv1.Policy) string {
+	switch policy.(type) {
+	case *policiesv1.AdmissionPolicy:
+		return "namespaced-" + policy.GetNamespace() + "-" + policy.GetName()
+	case *policiesv1.AdmissionPolicyGroup:
+		return "namespaced-group-" + policy.GetNamespace() + "-" + policy.GetName()
+	case *policiesv1.ClusterAdmissionPolicy:
+		return "clusterwide-" + policy.GetName()
+	case *policiesv1.ClusterAdmissionPolicyGroup:
+		return "clusterwide-group-" + policy.GetName()
+	default:
+		return ""
+	}
+}
+
+// reconcileLegacyWebhookConfigurationCleanup deletes the webhook
+// configurations that were created for the given policy using the legacy
+// unique name. Both the validating and the mutating configurations are
+// checked, since the policy's `mutating` flag could have changed since they
+// were created. Only objects carrying the Kubewarden labels are removed.
+func (r *policySubReconciler) reconcileLegacyWebhookConfigurationCleanup(ctx context.Context, policy policiesv1.Policy) error {
+	legacyName := legacyPolicyUniqueName(policy)
+	if legacyName == "" {
+		return nil
+	}
+
+	validatingWebhook := admissionregistrationv1.ValidatingWebhookConfiguration{}
+	err := r.Get(ctx, types.NamespacedName{Name: legacyName}, &validatingWebhook)
+	if err == nil && hasKubewardenLabel(validatingWebhook.GetLabels()) {
+		deleteErr := r.Delete(ctx, &validatingWebhook, client.Preconditions{UID: &validatingWebhook.UID})
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) && !apierrors.IsConflict(deleteErr) {
+			return fmt.Errorf("cannot delete legacy validating webhook: %w", deleteErr)
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("cannot retrieve legacy validating webhook: %w", err)
+	}
+
+	mutatingWebhook := admissionregistrationv1.MutatingWebhookConfiguration{}
+	err = r.Get(ctx, types.NamespacedName{Name: legacyName}, &mutatingWebhook)
+	if err == nil && hasKubewardenLabel(mutatingWebhook.GetLabels()) {
+		deleteErr := r.Delete(ctx, &mutatingWebhook, client.Preconditions{UID: &mutatingWebhook.UID})
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) && !apierrors.IsConflict(deleteErr) {
+			return fmt.Errorf("cannot delete legacy mutating webhook: %w", deleteErr)
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("cannot retrieve legacy mutating webhook: %w", err)
+	}
+
+	return nil
+}
+
+// addLegacyPolicyEntries adds, for every policy already present in the map
+// under its new unique name, the same configuration entry under the legacy
+// unique name. This keeps the legacy admission paths served by the
+// policy-server during the migration window, i.e. while webhook
+// configurations created with the legacy names still exist.
+//
+// The legacy encoding is ambiguous: distinct policies can map to the same
+// legacy name. When that happens, no entry is written for the contended
+// legacy name. Serving one of the colliding policies under it would re-open
+// the vulnerability this migration is part of fixing: the winning policy
+// would be evaluated in place of the others. At worst, the omission turns the
+// collision into a short-lived, self-healing dead admission path.
+func addLegacyPolicyEntries(policies policyConfigEntryMap, admissionPolicies []policiesv1.Policy, log logr.Logger) {
+	legacyNameOwners := make(map[string][]policiesv1.Policy, len(admissionPolicies))
+	for _, admissionPolicy := range admissionPolicies {
+		legacyName := legacyPolicyUniqueName(admissionPolicy)
+		if legacyName == "" {
+			continue
+		}
+		legacyNameOwners[legacyName] = append(legacyNameOwners[legacyName], admissionPolicy)
+	}
+
+	for legacyName, owners := range legacyNameOwners {
+		if len(owners) > 1 {
+			colliding := make([]string, 0, len(owners))
+			for _, owner := range owners {
+				colliding = append(colliding, owner.GetUniqueName())
+			}
+			log.Info(
+				"skipping legacy configuration entry: multiple policies map to the same legacy unique name",
+				"legacyName", legacyName,
+				"policies", colliding,
+			)
+			continue
+		}
+
+		if entry, ok := policies[owners[0].GetUniqueName()]; ok {
+			policies[legacyName] = entry
+		}
+	}
+}

--- a/internal/controller/legacy_policy_migration_test.go
+++ b/internal/controller/legacy_policy_migration_test.go
@@ -1,0 +1,203 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
+	"github.com/kubewarden/adm-controller/internal/constants"
+)
+
+func TestLegacyPolicyUniqueName(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   policiesv1.Policy
+		expected string
+	}{
+		{
+			name: "AdmissionPolicy",
+			policy: &policiesv1.AdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+			},
+			expected: "namespaced-tenant-prod-baseline",
+		},
+		{
+			name: "AdmissionPolicyGroup",
+			policy: &policiesv1.AdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+			},
+			expected: "namespaced-group-tenant-prod-baseline",
+		},
+		{
+			name: "ClusterAdmissionPolicy",
+			policy: &policiesv1.ClusterAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "baseline"},
+			},
+			expected: "clusterwide-baseline",
+		},
+		{
+			name: "ClusterAdmissionPolicyGroup",
+			policy: &policiesv1.ClusterAdmissionPolicyGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "baseline"},
+			},
+			expected: "clusterwide-group-baseline",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, legacyPolicyUniqueName(test.policy))
+		})
+	}
+}
+
+func TestAddLegacyPolicyEntries(t *testing.T) {
+	policyServer := &policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	policy := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{Module: "registry://legit/module:v1"},
+		},
+	}
+
+	policies := buildPoliciesMap([]policiesv1.Policy{policy}, policyServer)
+	addLegacyPolicyEntries(policies, []policiesv1.Policy{policy}, logr.Discard())
+
+	require.Contains(t, policies, "kw.ap.tenant-prod.baseline")
+	require.Contains(t, policies, "namespaced-tenant-prod-baseline")
+	assert.Equal(t, policies["kw.ap.tenant-prod.baseline"], policies["namespaced-tenant-prod-baseline"])
+}
+
+// When distinct policies collide on the same legacy unique name, no legacy
+// entry must be written: serving one of them under the contended identity
+// would allow its module to evaluate admission requests meant for the other
+// (the vulnerability this migration code is part of fixing).
+func TestAddLegacyPolicyEntriesSkipsCollidingLegacyNames(t *testing.T) {
+	policyServer := &policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	victim := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{Module: "registry://legit/module:v1"},
+		},
+	}
+	attacker := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "prod-baseline"},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{Module: "registry://attacker/module:v1"},
+		},
+	}
+	allPolicies := []policiesv1.Policy{victim, attacker}
+
+	policies := buildPoliciesMap(allPolicies, policyServer)
+	addLegacyPolicyEntries(policies, allPolicies, logr.Discard())
+
+	// Both policies are served under their new, unambiguous names.
+	require.Contains(t, policies, "kw.ap.tenant-prod.baseline")
+	require.Contains(t, policies, "kw.ap.tenant.prod-baseline")
+	// The contended legacy name is not served at all.
+	assert.NotContains(t, policies, "namespaced-tenant-prod-baseline")
+}
+
+// Cross-kind collisions on the legacy encoding must be skipped as well.
+func TestAddLegacyPolicyEntriesSkipsCrossKindCollisions(t *testing.T) {
+	policyServer := &policiesv1.PolicyServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	policy := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "group-x", Name: "y"},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{Module: "registry://legit/module:v1"},
+		},
+	}
+	group := policiesv1.NewAdmissionPolicyGroupFactory().
+		WithNamespace("x").
+		WithName("y").
+		Build()
+	allPolicies := []policiesv1.Policy{policy, group}
+
+	policies := buildPoliciesMap(allPolicies, policyServer)
+	addLegacyPolicyEntries(policies, allPolicies, logr.Discard())
+
+	require.Contains(t, policies, "kw.ap.group-x.y")
+	require.Contains(t, policies, "kw.apg.x.y")
+	assert.NotContains(t, policies, "namespaced-group-x-y")
+}
+
+func TestReconcileLegacyWebhookConfigurationCleanup(t *testing.T) {
+	policy := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	legacyName := legacyPolicyUniqueName(policy)
+
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		expectDeletion bool
+	}{
+		{
+			name:           "deletes legacy webhook configurations with the part-of label",
+			labels:         map[string]string{constants.PartOfLabelKey: constants.PartOfLabelValue},
+			expectDeletion: true,
+		},
+		{
+			name:           "deletes legacy webhook configurations with the pre v1.16.0 label",
+			labels:         map[string]string{"kubewarden": "true"},
+			expectDeletion: true,
+		},
+		{
+			name:           "does not delete webhook configurations not managed by Kubewarden",
+			labels:         map[string]string{},
+			expectDeletion: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validatingWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyName, Labels: test.labels},
+			}
+			mutatingWebhook := &admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: legacyName, Labels: test.labels},
+			}
+			k8sClient := fake.NewClientBuilder().WithObjects(validatingWebhook, mutatingWebhook).Build()
+			reconciler := &policySubReconciler{Client: k8sClient, Log: logr.Discard()}
+
+			err := reconciler.reconcileLegacyWebhookConfigurationCleanup(t.Context(), policy)
+			require.NoError(t, err)
+
+			validatingErr := k8sClient.Get(t.Context(), types.NamespacedName{Name: legacyName}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
+			mutatingErr := k8sClient.Get(t.Context(), types.NamespacedName{Name: legacyName}, &admissionregistrationv1.MutatingWebhookConfiguration{})
+			if test.expectDeletion {
+				assert.True(t, apierrors.IsNotFound(validatingErr))
+				assert.True(t, apierrors.IsNotFound(mutatingErr))
+			} else {
+				assert.NoError(t, validatingErr)
+				assert.NoError(t, mutatingErr)
+			}
+		})
+	}
+}
+
+func TestReconcileLegacyWebhookConfigurationCleanupNoLegacyWebhooks(t *testing.T) {
+	policy := &policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-prod", Name: "baseline"},
+	}
+	k8sClient := fake.NewClientBuilder().Build()
+	reconciler := &policySubReconciler{Client: k8sClient, Log: logr.Discard()}
+
+	err := reconciler.reconcileLegacyWebhookConfigurationCleanup(t.Context(), policy)
+	require.NoError(t, err)
+}

--- a/internal/controller/policy_subreconciler.go
+++ b/internal/controller/policy_subreconciler.go
@@ -143,6 +143,14 @@ func (r *policySubReconciler) reconcilePolicy(ctx context.Context, policy polici
 	if err = r.reconcileWebhookConfiguration(ctx, policy, &secret, policyServer.NameWithPrefix()); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Remove the webhook configurations created with the legacy, ambiguous
+	// unique name by previous versions of the controller. This migration code
+	// can be safely removed after a few releases.
+	if err = r.reconcileLegacyWebhookConfigurationCleanup(ctx, policy); err != nil {
+		return ctrl.Result{}, errors.Join(errors.New("error cleaning up legacy webhook configurations"), err)
+	}
+
 	setPolicyAsActive(policy)
 
 	return ctrl.Result{}, nil
@@ -191,6 +199,15 @@ func (r *policySubReconciler) deleteWebhookConfiguration(ctx context.Context, po
 // policy finalizers.
 func (r *policySubReconciler) removePolicyWebhooksAndFinalizers(ctx context.Context, policy policiesv1.Policy) error {
 	if err := r.deleteWebhookConfiguration(ctx, policy); err != nil {
+		return err
+	}
+
+	// Remove the webhook configurations created with the legacy, ambiguous
+	// unique name by previous versions of the controller, so that policies
+	// deleted before being reconciled by this version of the controller do
+	// not leave orphaned webhook configurations behind. This migration code
+	// can be safely removed after a few releases.
+	if err := r.reconcileLegacyWebhookConfigurationCleanup(ctx, policy); err != nil {
 		return err
 	}
 

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	policiesv1 "github.com/kubewarden/adm-controller/api/policies/v1"
@@ -94,8 +95,9 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfigurationDeletion(ct
 	webhook := admissionregistrationv1.ValidatingWebhookConfiguration{}
 	err := r.Get(ctx, types.NamespacedName{Name: admissionPolicy.GetUniqueName()}, &webhook)
 	if err == nil {
-		if err = r.Delete(ctx, &webhook); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("cannot delete validating webhook: %w", err)
+		deleteErr := r.Delete(ctx, &webhook, client.Preconditions{UID: &webhook.UID})
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) && !apierrors.IsConflict(deleteErr) {
+			return fmt.Errorf("cannot delete validating webhook: %w", deleteErr)
 		}
 	} else if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("cannot retrieve validating webhook: %w", err)
@@ -180,8 +182,9 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfigurationDeletion(ctx 
 	webhook := admissionregistrationv1.MutatingWebhookConfiguration{}
 	err := r.Get(ctx, types.NamespacedName{Name: admissionPolicy.GetUniqueName()}, &webhook)
 	if err == nil {
-		if err = r.Delete(ctx, &webhook); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("cannot delete mutating webhook: %w", err)
+		deleteErr := r.Delete(ctx, &webhook, client.Preconditions{UID: &webhook.UID})
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) && !apierrors.IsConflict(deleteErr) {
+			return fmt.Errorf("cannot delete mutating webhook: %w", deleteErr)
 		}
 	} else if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("cannot retrieve mutating webhook: %w", err)

--- a/internal/controller/policy_subreconciler_webhook.go
+++ b/internal/controller/policy_subreconciler_webhook.go
@@ -59,7 +59,7 @@ func (r *policySubReconciler) reconcileValidatingWebhookConfiguration(
 
 		webhook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 			{
-				Name: policy.GetUniqueName() + ".kubewarden.admission",
+				Name: policy.GetUniqueName() + constants.WebhookNameSuffix,
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service:  &service,
 					CABundle: admissionSecret.Data[constants.CARootCert],
@@ -146,7 +146,7 @@ func (r *policySubReconciler) reconcileMutatingWebhookConfiguration(
 		}
 		webhook.Webhooks = []admissionregistrationv1.MutatingWebhook{
 			{
-				Name: policy.GetUniqueName() + ".kubewarden.admission",
+				Name: policy.GetUniqueName() + constants.WebhookNameSuffix,
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service:  &service,
 					CABundle: admissionSecret.Data[constants.CARootCert],

--- a/internal/controller/policyserver_controller_configmap.go
+++ b/internal/controller/policyserver_controller_configmap.go
@@ -149,6 +149,11 @@ func (r *PolicyServerReconciler) reconcilePolicyServerConfigMap(
 // Function used to update the ConfigMap data when creating or updating it.
 func (r *PolicyServerReconciler) updateConfigMapData(cfg *corev1.ConfigMap, policyServer *policiesv1.PolicyServer, policies []policiesv1.Policy) error {
 	policiesMap := buildPoliciesMap(policies, policyServer)
+	// Serve each policy also under its legacy unique name, so that webhook
+	// configurations created with the legacy names by previous versions of
+	// the controller keep working until they are migrated. This migration
+	// code can be safely removed after a few releases.
+	addLegacyPolicyEntries(policiesMap, policies, r.Log)
 	policiesYML, err := json.Marshal(policiesMap)
 	if err != nil {
 		return fmt.Errorf("cannot marshal policies: %w", err)

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -417,6 +418,15 @@ var _ = Describe("PolicyServer controller", func() {
 				Message:               clusterPolicyGroup.GetMessage(),
 				TimeoutEvalSeconds:    &timeoutEvalSeconds,
 			}
+
+			// During the migration away from the legacy unique names, the
+			// configuration also serves every policy under its legacy name.
+			addLegacyPolicyEntries(policiesMap, []policiesv1.Policy{
+				admissionPolicy,
+				clusterAdmissionPolicy,
+				admissionPolicyGroup,
+				clusterPolicyGroup,
+			}, logr.Discard())
 
 			policies, err := json.Marshal(policiesMap)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/policyserver_controller_test.go
+++ b/internal/controller/policyserver_controller_test.go
@@ -1877,7 +1877,7 @@ var _ = Describe("PolicyServer controller", func() {
 					},
 					Webhooks: []admissionregistrationv1.ValidatingWebhook{
 						{
-							Name:                    policy.GetUniqueName() + ".kubewarden.admission",
+							Name:                    policy.GetUniqueName() + constants.WebhookNameSuffix,
 							AdmissionReviewVersions: []string{"v1"},
 							SideEffects: func() *admissionregistrationv1.SideEffectClass {
 								s := admissionregistrationv1.SideEffectClassNone


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix [GHSA-m5vp-9g65-pv6v](https://github.com/kubewarden/adm-controller/security/advisories/GHSA-m5vp-9g65-pv6v).

The admission controller had two related issues with how policy identities were encoded into webhook configuration names:
- Naming clashes: The previous encoding method could produce identical webhook configuration names for distinct policies, causing some policies to collide on shared paths and ConfigMap keys, silently failing to become active.
-  Silent reconciliation failures: When a policy name and namespace combination derived a webhook entry name exceeding the DNS1123 subdomain length limit (253 characters), the policy was accepted at creation time but failed silently at reconciliation time, never becoming active.

We now use an injective dot-delimited encoding scheme (`kw.ap.<namespace>.<name>`, `kw.apg.<namespace>.<name>`, etc.) that eliminates naming clashes and produces identities more useful for debugging.

We also validate the derived webhook name length at policy creation time, providing an actionable error that states the maximum name length allowed for the given namespace and kind.

## Upgrade from an older version of admission-controller

Webhook configurations and policy-server deployments are reconciled by independent loops, so during upgrade a webhook created with the previous identity can briefly outlive a policy-server rollout that already serves only the new one.

To avoid short denial of services:
- The controller now serves both legacy and new identities simultaneously via dual-key ConfigMap entries, keeping those webhooks routable until they are migrated.
- The mapping is skipped whenever two policies would share a previous identity (collision-aware).
- Webhook configurations left behind under the previous identity are cleaned up during reconciliation.
- 
This transitional and cleanup code can be removed after a few releases, once no resource created by an older controller remains.

## Testing
- Unit tests cover collision detection across namespaces, kinds, and dotted policy names
- End-to-end tests verify the legacy webhook migration path
- Name-length validation tested at DNS1123 limits for all four policy kinds
- Full e2e suite passes


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
