### PR TITLE
refactor(policy-evaluator): Move from cached to moka, free mem automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,27 +740,11 @@ checksum = "53b6f5d101f0f6322c8646a45b7c581a673e476329040d97565815c2461dd0c4"
 dependencies = [
  "ahash",
  "async-trait",
- "cached_proc_macro 0.27.0",
- "cached_proc_macro_types 0.1.1",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
  "futures",
  "hashbrown 0.16.1",
  "once_cell",
- "parking_lot",
- "thiserror 2.0.20",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "cached"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0df7748fe2f601e376916ab19e7bfc2c74461b8abe3bce2ce20036ad8de38f"
-dependencies = [
- "ahash",
- "cached_proc_macro 2.0.0",
- "cached_proc_macro_types 1.0.0",
- "hashbrown 0.16.1",
  "parking_lot",
  "thiserror 2.0.20",
  "tokio",
@@ -780,28 +764,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cached_proc_macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e734c52502e6cf54dce2ba07108906b04b8fe57f4f5e3ef7d58267b4abf060"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cap-fs-ext"
@@ -4910,7 +4876,6 @@ dependencies = [
  "base64 0.23.1",
  "burrego",
  "bytes",
- "cached 2.0.2",
  "chrono",
  "dns-lookup",
  "email_address",
@@ -6552,7 +6517,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "base64 0.22.1",
- "cached 0.59.0",
+ "cached",
  "cfg-if",
  "chrono",
  "const-oid 0.9.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,43 +733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
-name = "cached"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b6f5d101f0f6322c8646a45b7c581a673e476329040d97565815c2461dd0c4"
-dependencies = [
- "ahash",
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.16.1",
- "once_cell",
- "parking_lot",
- "thiserror 2.0.20",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebcf9c75f17a17d55d11afc98e46167d4790a263f428891b8705ab2f793eca3"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
-
-[[package]]
 name = "cap-fs-ext"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,7 +6480,6 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "base64 0.22.1",
- "cached",
  "cfg-if",
  "chrono",
  "const-oid 0.9.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +332,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -528,7 +539,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -845,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -993,7 +1004,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1383,9 +1394,9 @@ checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1932,7 +1943,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2037,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.18.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -2124,7 +2135,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2462,7 +2473,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2677,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3094,9 +3105,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3276,15 +3287,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3852,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -3870,9 +3872,9 @@ checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "mail-parser"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a9080c1fb8190e232df37a10aa1b3d6b08be084e537069913f025e0ce86c5"
+checksum = "4084ec5c2f90b341d0c70990e92a23b128f75ca14fc1dd5edd8fd5c9b417da4d"
 dependencies = [
  "hashify",
  "serde",
@@ -4025,6 +4027,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -4902,6 +4924,7 @@ dependencies = [
  "kubewarden-policy-sdk",
  "lazy_static",
  "mail-parser",
+ "moka",
  "policy-fetcher",
  "rcgen",
  "reqwest 0.12.28",
@@ -5222,7 +5245,7 @@ dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5418,9 +5441,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.17"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5626,22 +5649,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6000,9 +6023,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.15"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6099,7 +6122,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6254,7 +6277,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6265,7 +6288,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6320,7 +6343,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6412,7 +6435,7 @@ checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6579,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "sigstore_protobuf_specs"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423fc484041de8195cf21dc8888463e74e8cbb3487e36c14373abeaef1f96125"
+checksum = "cd627b4d5240ac660de3357b5d0156d5c63b872be1deae5046c3c8eb65d488e2"
 dependencies = [
  "anyhow",
  "glob",
@@ -6839,9 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6888,6 +6911,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -6950,9 +6979,9 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.35.2"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc986efe2e680fbd1051790103f01b176eb6b1bbc926e41d46adfe44ea43614c"
+checksum = "d53d4b1294b87e81925b7ae7f8f4d000376e3a5b3349d978429665428a793fcb"
 dependencies = [
  "coolor",
  "crokey",
@@ -7111,7 +7140,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7270,7 +7299,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7776,10 +7805,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -7851,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.26.5"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b63a2bc6e4acb4cf69080068a531bad4530791098230e972ffcb64fd1dc266"
+checksum = "3bfa49767bb3a9e1afb02aa95bbcbde8d82f2db4ca377afae94d688f14f62378"
 dependencies = [
  "anyhow",
  "gimli 0.32.3",
@@ -8018,6 +8048,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.256.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
@@ -8075,6 +8115,17 @@ dependencies = [
  "indexmap 2.14.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -8405,24 +8456,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "257.0.1"
+version = "256.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
+checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.257.1",
+ "wasm-encoder 0.256.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.257.1"
+version = "1.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
+checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
 dependencies = [
- "wast 257.0.1",
+ "wast 256.0.0",
 ]
 
 [[package]]
@@ -8925,9 +8976,9 @@ dependencies = [
 
 [[package]]
 name = "yaml_serde"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
+checksum = "ad7a8266fc7ce9d77db272ca5b40b704a1753e2a2e2ab7b1f2da22672941bf93"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -9043,9 +9094,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.8"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9054,13 +9105,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/crates/kwctl/src/callback_handler/mod.rs
+++ b/crates/kwctl/src/callback_handler/mod.rs
@@ -24,8 +24,8 @@ pub(crate) enum ProxyMode {
 /// The goal is to allow kwctl to have a proxy handler, that can
 /// record and reply any kind of policy <-> host capability exchange
 pub(crate) enum CallbackHandler {
-    Direct(policy_evaluator::callback_handler::CallbackHandler),
-    Proxy(proxy::CallbackHandlerProxy),
+    Direct(Box<policy_evaluator::callback_handler::CallbackHandler>),
+    Proxy(Box<proxy::CallbackHandlerProxy>),
 }
 
 impl CallbackHandler {
@@ -90,7 +90,7 @@ async fn new_proxy(
     )
     .await?;
 
-    Ok(CallbackHandler::Proxy(proxy))
+    Ok(CallbackHandler::Proxy(Box::new(proxy)))
 }
 
 async fn new_transparent(
@@ -108,5 +108,5 @@ async fn new_transparent(
 
     let real_callback_handler = callback_handler_builder.build().await?;
 
-    Ok(CallbackHandler::Direct(real_callback_handler))
+    Ok(CallbackHandler::Direct(Box::new(real_callback_handler)))
 }

--- a/crates/kwctl/src/verify.rs
+++ b/crates/kwctl/src/verify.rs
@@ -23,7 +23,7 @@ pub(crate) async fn verify(
         ?verification_config,
         "Verifying policy"
     );
-    let mut verifier = Verifier::new(sources.cloned(), sigstore_trust_root).await?;
+    let verifier = Verifier::new(sources.cloned(), sigstore_trust_root).await?;
     let verified_manifest_digest = verifier.verify(url, verification_config).await?;
 
     info!("Policy successfully verified");
@@ -36,7 +36,7 @@ pub(crate) async fn verify_local_checksum(
     verified_manifest_digest: &str,
     sigstore_trust_root: Option<Arc<SigstoreTrustRoot>>,
 ) -> Result<()> {
-    let mut verifier = Verifier::new(sources.cloned(), sigstore_trust_root).await?;
+    let verifier = Verifier::new(sources.cloned(), sigstore_trust_root).await?;
     verifier
         .verify_local_file_checksum(policy, verified_manifest_digest)
         .await?;

--- a/crates/policy-evaluator/Cargo.toml
+++ b/crates/policy-evaluator/Cargo.toml
@@ -17,6 +17,7 @@ base64 = { workspace = true }
 burrego = { path = "../burrego" }
 bytes = "1"
 cached = { version = "2.0", features = ["async_tokio_rt_multi_thread"] }
+moka = { version = "0.12", features = ["future"] }
 chrono = { version = "0.4", default-features = false }
 dns-lookup = "3.0"
 email_address = { version = "0.2", features = ["serde"] }

--- a/crates/policy-evaluator/Cargo.toml
+++ b/crates/policy-evaluator/Cargo.toml
@@ -16,8 +16,6 @@ async-trait = "0.1"
 base64 = { workspace = true }
 burrego = { path = "../burrego" }
 bytes = "1"
-cached = { version = "2.0", features = ["async_tokio_rt_multi_thread"] }
-moka = { version = "0.12", features = ["future"] }
 chrono = { version = "0.4", default-features = false }
 dns-lookup = "3.0"
 email_address = { version = "0.2", features = ["serde"] }
@@ -34,6 +32,7 @@ kube = { version = "4", default-features = false, features = [
 kubewarden-policy-sdk = { workspace = true, features = ["crd"] }
 lazy_static = { workspace = true }
 mail-parser = { version = "0.11", features = ["serde"] }
+moka = { version = "0.12", features = ["future"] }
 pki-types = { package = "rustls-pki-types", version = "1.14", default-features = false, features = [
   "std",
 ] }

--- a/crates/policy-evaluator/src/callback_handler.rs
+++ b/crates/policy-evaluator/src/callback_handler.rs
@@ -9,6 +9,7 @@ use crate::callback_handler::kubernetes::field_mask;
 use crate::callback_requests::{CallbackRequest, CallbackRequestType, CallbackResponse};
 
 mod builder;
+mod cache_return;
 mod crypto;
 mod kubernetes;
 mod oci;

--- a/crates/policy-evaluator/src/callback_handler.rs
+++ b/crates/policy-evaluator/src/callback_handler.rs
@@ -93,8 +93,8 @@ impl CallbackHandler {
 
     async fn handle_request(&mut self, req: CallbackRequest) {
         let oci_client = self.oci_client.clone();
-        let mut sigstore_client = self.sigstore_client.clone();
-        let mut kubernetes_client = self.kubernetes_client.clone();
+        let sigstore_client = self.sigstore_client.clone();
+        let kubernetes_client = self.kubernetes_client.clone();
 
         tokio::spawn(async move {
             match req.request {
@@ -120,7 +120,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore pub key verification done", {
                         get_sigstore_pub_key_verification_cached(
-                            &mut sigstore_client,
+                            &sigstore_client,
                             image.clone(),
                             pub_keys,
                             annotations,
@@ -134,7 +134,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore keyless verification done", {
                         get_sigstore_keyless_verification_cached(
-                            &mut sigstore_client,
+                            &sigstore_client,
                             image.clone(),
                             keyless,
                             annotations,
@@ -148,7 +148,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore keyless prefix verification done", {
                         get_sigstore_keyless_prefix_verification_cached(
-                            &mut sigstore_client,
+                            &sigstore_client,
                             image.clone(),
                             keyless_prefix,
                             annotations,
@@ -163,7 +163,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore GitHub Action verification done", {
                         get_sigstore_github_actions_verification_cached(
-                            &mut sigstore_client,
+                            &sigstore_client,
                             image.clone(),
                             owner,
                             repo,
@@ -180,7 +180,7 @@ impl CallbackHandler {
                 } => {
                     handle_callback!(req, image, "Sigstore GitHub Action verification done", {
                         get_sigstore_certificate_verification_cached(
-                            &mut sigstore_client,
+                            &sigstore_client,
                             &image,
                             &certificate,
                             certificate_chain.as_deref(),
@@ -219,7 +219,7 @@ impl CallbackHandler {
                         "List namespaced Kubernetes resource",
                         {
                             kubernetes::list_resources_by_namespace(
-                                kubernetes_client.as_mut(),
+                                kubernetes_client.as_ref(),
                                 &api_version,
                                 &kind,
                                 &namespace,
@@ -243,7 +243,7 @@ impl CallbackHandler {
                         "List Kubernetes resource",
                         {
                             kubernetes::list_resources_all(
-                                kubernetes_client.as_mut(),
+                                kubernetes_client.as_ref(),
                                 &api_version,
                                 &kind,
                                 label_selector,
@@ -268,7 +268,7 @@ impl CallbackHandler {
                             "Get Kubernetes resource - no cache",
                             {
                                 let res = kubernetes::get_resource(
-                                    kubernetes_client.as_mut(),
+                                    kubernetes_client.as_ref(),
                                     &api_version,
                                     &kind,
                                     &name,
@@ -293,7 +293,7 @@ impl CallbackHandler {
                             "Get Kubernetes resource",
                             {
                                 let res = kubernetes::get_resource_cached(
-                                    kubernetes_client.as_mut(),
+                                    kubernetes_client.as_ref(),
                                     &api_version,
                                     &kind,
                                     &name,
@@ -321,7 +321,7 @@ impl CallbackHandler {
                         "Get Kubernetes resource plural name",
                         {
                             kubernetes::get_resource_plural_name(
-                                kubernetes_client.as_mut(),
+                                kubernetes_client.as_ref(),
                                 &api_version,
                                 &kind,
                             )
@@ -342,7 +342,7 @@ impl CallbackHandler {
                         "Has the result of 'Kubernetes list all resources' changed since a given instant",
                         {
                             kubernetes::has_list_resources_all_result_changed_since_instant(
-                                kubernetes_client.as_mut(),
+                                kubernetes_client.as_ref(),
                                 &api_version,
                                 &kind,
                                 label_selector,
@@ -362,14 +362,14 @@ impl CallbackHandler {
                             req,
                             "can_i".to_owned(),
                             "Check if user or service account has permission to perform operation",
-                            { kubernetes::can_i(kubernetes_client.as_mut(), request) }
+                            { kubernetes::can_i(kubernetes_client.as_ref(), request) }
                         )
                     } else {
                         handle_callback!(
                             req,
                             "can_i".to_owned(),
                             "Check if user or service account has permission to perform operation",
-                            { kubernetes::can_i_cached(kubernetes_client.as_mut(), request) }
+                            { kubernetes::can_i_cached(kubernetes_client.as_ref(), request) }
                         )
                     }
                 }

--- a/crates/policy-evaluator/src/callback_handler/cache_return.rs
+++ b/crates/policy-evaluator/src/callback_handler/cache_return.rs
@@ -12,10 +12,18 @@ pub(crate) struct Return<T> {
 
 impl<T> Return<T> {
     /// Wraps a value that did not come from the cache.
-    pub fn new(value: T) -> Self {
+    pub fn not_cached(value: T) -> Self {
         Return {
             value,
             was_cached: false,
+        }
+    }
+
+    /// Wraps a value that came from the cache.
+    pub fn cached(value: T) -> Self {
+        Return {
+            value,
+            was_cached: true,
         }
     }
 }
@@ -40,9 +48,10 @@ where
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
+    Ok(if entry.is_fresh() {
+        Return::not_cached(entry.into_value())
+    } else {
+        Return::cached(entry.into_value())
     })
 }
 

--- a/crates/policy-evaluator/src/callback_handler/cache_return.rs
+++ b/crates/policy-evaluator/src/callback_handler/cache_return.rs
@@ -1,0 +1,31 @@
+/// Wraps a callback handler function result. The `was_cached` flag shows if the value came from the
+/// cache.
+#[derive(Debug, Clone)]
+pub(crate) struct Return<T> {
+    pub value: T,
+    pub was_cached: bool,
+}
+
+impl<T> Return<T> {
+    /// Wraps a value that did not come from the cache.
+    pub fn new(value: T) -> Self {
+        Return {
+            value,
+            was_cached: false,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for Return<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> std::ops::DerefMut for Return<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}

--- a/crates/policy-evaluator/src/callback_handler/cache_return.rs
+++ b/crates/policy-evaluator/src/callback_handler/cache_return.rs
@@ -1,3 +1,7 @@
+use std::{future::Future, hash::Hash};
+
+use anyhow::{Result, anyhow};
+
 /// Wraps a callback handler function result. The `was_cached` flag shows if the value came from the
 /// cache.
 #[derive(Debug, Clone)]
@@ -14,6 +18,32 @@ impl<T> Return<T> {
             was_cached: false,
         }
     }
+}
+
+/// Looks up `key` inside of `cache`. On a miss, `init` is awaited to compute the value, which is
+/// then stored inside of the cache. Only successful results enter the cache.
+///
+/// This centralizes the moka `entry().or_try_insert_with()` dance used by all the caches owned by
+/// the callback handler's clients (Kubernetes, OCI registry, Sigstore verification).
+pub(crate) async fn try_cached<K, V>(
+    cache: &moka::future::Cache<K, V>,
+    key: K,
+    init: impl Future<Output = Result<V>>,
+) -> Result<Return<V>>
+where
+    K: Hash + Eq + Send + Sync + Clone + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    let entry = cache
+        .entry(key)
+        .or_try_insert_with(init)
+        .await
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
 impl<T> std::ops::Deref for Return<T> {

--- a/crates/policy-evaluator/src/callback_handler/crypto.rs
+++ b/crates/policy-evaluator/src/callback_handler/crypto.rs
@@ -85,54 +85,38 @@ fn verify_cert_chain(
     );
 
     match verification_result {
-        Ok(_) => Ok(Return {
-            value: CertificateVerificationResponse {
-                trusted: true,
-                reason: "".to_string(),
-            },
-            was_cached: false,
-        }),
-        Err(Error::InvalidSignatureForPublicKey) => Ok(Return {
-            value: CertificateVerificationResponse {
+        Ok(_) => Ok(Return::not_cached(CertificateVerificationResponse {
+            trusted: true,
+            reason: "".to_string(),
+        })),
+        Err(Error::InvalidSignatureForPublicKey) => {
+            Ok(Return::not_cached(CertificateVerificationResponse {
                 trusted: false,
                 reason: CERTIFICATE_NOT_TRUSTED_BY_CHAIN.to_string(),
-            },
-            was_cached: false,
-        }),
+            }))
+        }
         Err(Error::CertExpired {
             time: _,
             not_after: _,
-        }) => Ok(Return {
-            value: CertificateVerificationResponse {
-                trusted: false,
-                reason: CERTIFICATE_USED_AFTER_EXPIRATION.to_string(),
-            },
-            was_cached: false,
-        }),
+        }) => Ok(Return::not_cached(CertificateVerificationResponse {
+            trusted: false,
+            reason: CERTIFICATE_USED_AFTER_EXPIRATION.to_string(),
+        })),
         Err(Error::CertNotValidYet {
             time: _,
             not_before: _,
-        }) => Ok(Return {
-            value: CertificateVerificationResponse {
-                trusted: false,
-                reason: CERTIFICATE_USED_BEFORE_VALIDITY.to_string(),
-            },
-            was_cached: false,
-        }),
-        Err(Error::UnknownIssuer) => Ok(Return {
-            value: CertificateVerificationResponse {
-                trusted: false,
-                reason: CERTIFICATE_NOT_TRUSTED_BY_CHAIN.to_string(),
-            },
-            was_cached: false,
-        }),
-        Err(e) => Ok(Return {
-            value: CertificateVerificationResponse {
-                trusted: false,
-                reason: format!("Certificate not trusted: {}", e),
-            },
-            was_cached: false,
-        }),
+        }) => Ok(Return::not_cached(CertificateVerificationResponse {
+            trusted: false,
+            reason: CERTIFICATE_USED_BEFORE_VALIDITY.to_string(),
+        })),
+        Err(Error::UnknownIssuer) => Ok(Return::not_cached(CertificateVerificationResponse {
+            trusted: false,
+            reason: CERTIFICATE_NOT_TRUSTED_BY_CHAIN.to_string(),
+        })),
+        Err(e) => Ok(Return::not_cached(CertificateVerificationResponse {
+            trusted: false,
+            reason: format!("Certificate not trusted: {}", e),
+        })),
     }
 }
 

--- a/crates/policy-evaluator/src/callback_handler/crypto.rs
+++ b/crates/policy-evaluator/src/callback_handler/crypto.rs
@@ -1,4 +1,6 @@
 use anyhow::{Result, anyhow};
+
+use crate::callback_handler::cache_return::Return;
 use kubewarden_policy_sdk::host_capabilities::{
     crypto::{Certificate, CertificateEncoding},
     crypto_v1::{CertificateVerificationRequest, CertificateVerificationResponse},
@@ -31,7 +33,7 @@ fn get_certificate_der<'a>(cert: &'a Certificate) -> Result<CertificateDer<'a>> 
 /// of the root CA. Intermediate CAs are checked for expiration.
 pub fn verify_certificate(
     req: CertificateVerificationRequest,
-) -> Result<cached::Return<CertificateVerificationResponse>> {
+) -> Result<Return<CertificateVerificationResponse>> {
     let cert_der = get_certificate_der(&req.cert)?;
     let end_entity_certificate = EndEntityCert::try_from(&cert_der)
         .map_err(|e| anyhow!("Certificate is not a valid end-entity certificate: {}", e))?;
@@ -64,7 +66,7 @@ fn verify_cert_chain(
     cert_chain: Option<Vec<Certificate>>,
     end_entity_certificate: EndEntityCert,
     verification_time: UnixTime,
-) -> Result<cached::Return<CertificateVerificationResponse>> {
+) -> Result<Return<CertificateVerificationResponse>> {
     let cert_pool = match &cert_chain {
         None => CertificatePool::from_webpki_roots(),
         Some(chain) => CertificatePool::from_certificates(chain),
@@ -83,14 +85,14 @@ fn verify_cert_chain(
     );
 
     match verification_result {
-        Ok(_) => Ok(cached::Return {
+        Ok(_) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: true,
                 reason: "".to_string(),
             },
             was_cached: false,
         }),
-        Err(Error::InvalidSignatureForPublicKey) => Ok(cached::Return {
+        Err(Error::InvalidSignatureForPublicKey) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: false,
                 reason: CERTIFICATE_NOT_TRUSTED_BY_CHAIN.to_string(),
@@ -100,7 +102,7 @@ fn verify_cert_chain(
         Err(Error::CertExpired {
             time: _,
             not_after: _,
-        }) => Ok(cached::Return {
+        }) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: false,
                 reason: CERTIFICATE_USED_AFTER_EXPIRATION.to_string(),
@@ -110,21 +112,21 @@ fn verify_cert_chain(
         Err(Error::CertNotValidYet {
             time: _,
             not_before: _,
-        }) => Ok(cached::Return {
+        }) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: false,
                 reason: CERTIFICATE_USED_BEFORE_VALIDITY.to_string(),
             },
             was_cached: false,
         }),
-        Err(Error::UnknownIssuer) => Ok(cached::Return {
+        Err(Error::UnknownIssuer) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: false,
                 reason: CERTIFICATE_NOT_TRUSTED_BY_CHAIN.to_string(),
             },
             was_cached: false,
         }),
-        Err(e) => Ok(cached::Return {
+        Err(e) => Ok(Return {
             value: CertificateVerificationResponse {
                 trusted: false,
                 reason: format!("Certificate not trusted: {}", e),

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
+use std::sync::LazyLock;
+use std::time::Duration;
 
 mod client;
 pub(crate) mod field_mask;
 mod reflector;
 
 use anyhow::{Result, anyhow};
-use cached::macros::cached;
 use k8s_openapi::api::authorization::v1::SubjectAccessReviewStatus;
 use kube::core::ObjectList;
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
@@ -98,13 +99,19 @@ pub(crate) async fn get_resource(
         })
 }
 
-#[cached(
-    ttl = 5,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("get_resource_cached({},{}),{},{:?}", api_version, kind, name, namespace) }"#,
-    with_cached_flag = true
-)]
+// A query to the Kubernetes API server is slow. This cache keeps the resource results,
+// which are full Kubernetes objects.
+// This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the resource identity: API version, kind, name, and namespace.
+// Only successful results enter the cache.
+static GET_RESOURCE_CACHE: LazyLock<moka::future::Cache<String, kube::core::DynamicObject>> =
+    LazyLock::new(|| {
+        moka::future::Cache::builder()
+            .time_to_live(Duration::from_secs(5))
+            .build()
+    });
+
 pub(crate) async fn get_resource_cached(
     client: Option<&mut Client>,
     api_version: &str,
@@ -112,7 +119,21 @@ pub(crate) async fn get_resource_cached(
     name: &str,
     namespace: Option<&str>,
 ) -> Result<cached::Return<kube::core::DynamicObject>> {
-    get_resource(client, api_version, kind, name, namespace).await
+    let key = format!("get_resource_cached({api_version},{kind}),{name},{namespace:?}");
+    let entry = GET_RESOURCE_CACHE
+        .entry(key)
+        .or_try_insert_with(async {
+            get_resource(client, api_version, kind, name, namespace)
+                .await
+                .map(|response| response.value)
+        })
+        .await
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
 pub(crate) async fn get_resource_plural_name(
@@ -183,20 +204,33 @@ pub(crate) async fn can_i(
         })
 }
 
-#[cached(
-    ttl = 5,
-    // We can use the request type as key because cached requires the key to implement Hash + Eq
-    // traits. As we already implement these traits, there is no need to have a custom logic for key
-    // generation. If we do that, we will only convert it into a type (e.g. string)  that
-    // implements the traits as well. 
-    key = "KWSubjectAccessReview",
-    convert = r#"{request.clone()}"#,
-    sync_writes = "default",
-    with_cached_flag = true
-)]
+// A query to the Kubernetes API server is slow. This cache keeps the SubjectAccessReview
+// results.
+// This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the full SubjectAccessReview request, because the type implements the Hash and
+// Eq traits.
+// Only successful results enter the cache.
+static CAN_I_CACHE: LazyLock<
+    moka::future::Cache<KWSubjectAccessReview, SubjectAccessReviewStatus>,
+> = LazyLock::new(|| {
+    moka::future::Cache::builder()
+        .time_to_live(Duration::from_secs(5))
+        .build()
+});
+
 pub(crate) async fn can_i_cached(
     client: Option<&mut Client>,
     request: KWSubjectAccessReview,
 ) -> Result<cached::Return<SubjectAccessReviewStatus>> {
-    can_i(client, request).await
+    let entry = CAN_I_CACHE
+        .entry(request.clone())
+        .or_try_insert_with(async { can_i(client, request).await.map(|response| response.value) })
+        .await
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -36,7 +36,7 @@ pub(crate) async fn list_resources_by_namespace(
     field_masks: Option<BTreeSet<String>>,
 ) -> Result<Return<ObjectList<kube::core::DynamicObject>>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::not_cached);
     }
 
     client
@@ -50,7 +50,7 @@ pub(crate) async fn list_resources_by_namespace(
             field_masks,
         )
         .await
-        .map(Return::new)
+        .map(Return::not_cached)
 }
 
 pub(crate) async fn list_resources_all(
@@ -62,7 +62,7 @@ pub(crate) async fn list_resources_all(
     field_masks: Option<BTreeSet<String>>,
 ) -> Result<Return<ObjectList<kube::core::DynamicObject>>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::not_cached);
     }
 
     client
@@ -75,7 +75,7 @@ pub(crate) async fn list_resources_all(
             field_masks,
         )
         .await
-        .map(Return::new)
+        .map(Return::not_cached)
 }
 
 pub(crate) async fn get_resource(
@@ -93,10 +93,7 @@ pub(crate) async fn get_resource(
         .unwrap()
         .get_resource(api_version, kind, name, namespace)
         .await
-        .map(|value| Return {
-            was_cached: false,
-            value,
-        })
+        .map(Return::not_cached)
 }
 
 pub(crate) async fn get_resource_cached(
@@ -129,12 +126,9 @@ pub(crate) async fn get_resource_plural_name(
         .unwrap()
         .get_resource_plural_name(api_version, kind)
         .await
-        .map(|value| Return {
-            // this is always cached, because the client builds an overview of
-            // the cluster resources at bootstrap time
-            was_cached: true,
-            value,
-        })
+        // this is always cached, because the client builds an overview of
+        // the cluster resources at bootstrap time
+        .map(Return::cached)
 }
 
 /// Check if the results of the "list all resources" query have changed since the provided instant
@@ -149,7 +143,7 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
     since: tokio::time::Instant,
 ) -> Result<Return<bool>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::not_cached);
     }
 
     client
@@ -163,7 +157,7 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
             since,
         )
         .await
-        .map(Return::new)
+        .map(Return::not_cached)
 }
 
 pub(crate) async fn can_i(
@@ -174,10 +168,7 @@ pub(crate) async fn can_i(
         return Err(anyhow!("kube::Client was not initialized properly"));
     }
 
-    client.unwrap().can_i(request).await.map(|value| Return {
-        was_cached: false,
-        value,
-    })
+    client.unwrap().can_i(request).await.map(Return::not_cached)
 }
 
 pub(crate) async fn can_i_cached(

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -232,3 +232,65 @@ pub(crate) async fn can_i_cached(
         value: entry.into_value(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use hyper::{Request, Response};
+    use k8s_openapi::api::authorization::v1::SubjectAccessReview;
+    use kube::client::Body;
+
+    use super::*;
+
+    // Ensure that the can_i cache deduplicates the backend calls. The test calls can_i_cached two
+    // times with the same request. The mock API server must receive exactly one SubjectAccessReview
+    // POST: the second call is a cache hit.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn can_i_cached_deduplicates_backend_calls() {
+        let (mocksvc, mut handle) = tower_test::mock::pair::<Request<Body>, Response<Body>>();
+        let sar_counter = Arc::new(AtomicUsize::new(0));
+
+        let counter = sar_counter.clone();
+        tokio::spawn(async move {
+            loop {
+                let (request, send) = handle.next_request().await.expect("service not called");
+                assert_eq!(
+                    request.uri().path(),
+                    "/apis/authorization.k8s.io/v1/subjectaccessreviews"
+                );
+                counter.fetch_add(1, Ordering::SeqCst);
+
+                let response = SubjectAccessReview {
+                    status: Some(SubjectAccessReviewStatus {
+                        allowed: false,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+                let body = serde_json::to_vec(&response).unwrap();
+                send.send_response(Response::builder().body(Body::from(body)).unwrap());
+            }
+        });
+
+        let mut client = Client::new(kube::Client::new(mocksvc, "default"));
+        let request = KWSubjectAccessReview {
+            // unique user name. This keeps the cache key separate from the keys of the other tests,
+            // because the cache is one process-wide static.
+            user: "system:serviceaccount:default:can-i-cached-dedup-test".to_owned(),
+            ..Default::default()
+        };
+
+        let first = can_i_cached(Some(&mut client), request.clone())
+            .await
+            .expect("first call failed");
+        let second = can_i_cached(Some(&mut client), request)
+            .await
+            .expect("second call failed");
+
+        assert!(!first.was_cached);
+        assert!(second.was_cached);
+        assert_eq!(1, sar_counter.load(Ordering::SeqCst));
+    }
+}

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -7,6 +7,8 @@ pub(crate) mod field_mask;
 mod reflector;
 
 use anyhow::{Result, anyhow};
+
+use crate::callback_handler::cache_return::Return;
 use k8s_openapi::api::authorization::v1::SubjectAccessReviewStatus;
 use kube::core::ObjectList;
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
@@ -34,9 +36,9 @@ pub(crate) async fn list_resources_by_namespace(
     label_selector: Option<String>,
     field_selector: Option<String>,
     field_masks: Option<BTreeSet<String>>,
-) -> Result<cached::Return<ObjectList<kube::core::DynamicObject>>> {
+) -> Result<Return<ObjectList<kube::core::DynamicObject>>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
     }
 
     client
@@ -50,7 +52,7 @@ pub(crate) async fn list_resources_by_namespace(
             field_masks,
         )
         .await
-        .map(cached::Return::new)
+        .map(Return::new)
 }
 
 pub(crate) async fn list_resources_all(
@@ -60,9 +62,9 @@ pub(crate) async fn list_resources_all(
     label_selector: Option<String>,
     field_selector: Option<String>,
     field_masks: Option<BTreeSet<String>>,
-) -> Result<cached::Return<ObjectList<kube::core::DynamicObject>>> {
+) -> Result<Return<ObjectList<kube::core::DynamicObject>>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
     }
 
     client
@@ -75,7 +77,7 @@ pub(crate) async fn list_resources_all(
             field_masks,
         )
         .await
-        .map(cached::Return::new)
+        .map(Return::new)
 }
 
 pub(crate) async fn get_resource(
@@ -84,7 +86,7 @@ pub(crate) async fn get_resource(
     kind: &str,
     name: &str,
     namespace: Option<&str>,
-) -> Result<cached::Return<kube::core::DynamicObject>> {
+) -> Result<Return<kube::core::DynamicObject>> {
     if client.is_none() {
         return Err(anyhow!("kube::Client was not initialized properly"));
     }
@@ -93,7 +95,7 @@ pub(crate) async fn get_resource(
         .unwrap()
         .get_resource(api_version, kind, name, namespace)
         .await
-        .map(|value| cached::Return {
+        .map(|value| Return {
             was_cached: false,
             value,
         })
@@ -118,7 +120,7 @@ pub(crate) async fn get_resource_cached(
     kind: &str,
     name: &str,
     namespace: Option<&str>,
-) -> Result<cached::Return<kube::core::DynamicObject>> {
+) -> Result<Return<kube::core::DynamicObject>> {
     let key = format!("get_resource_cached({api_version},{kind}),{name},{namespace:?}");
     let entry = GET_RESOURCE_CACHE
         .entry(key)
@@ -130,7 +132,7 @@ pub(crate) async fn get_resource_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -140,7 +142,7 @@ pub(crate) async fn get_resource_plural_name(
     client: Option<&mut Client>,
     api_version: &str,
     kind: &str,
-) -> Result<cached::Return<String>> {
+) -> Result<Return<String>> {
     if client.is_none() {
         return Err(anyhow!("kube::Client was not initialized properly"));
     }
@@ -149,7 +151,7 @@ pub(crate) async fn get_resource_plural_name(
         .unwrap()
         .get_resource_plural_name(api_version, kind)
         .await
-        .map(|value| cached::Return {
+        .map(|value| Return {
             // this is always cached, because the client builds an overview of
             // the cluster resources at bootstrap time
             was_cached: true,
@@ -167,9 +169,9 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
     field_selector: Option<String>,
     field_masks: Option<BTreeSet<String>>,
     since: tokio::time::Instant,
-) -> Result<cached::Return<bool>> {
+) -> Result<Return<bool>> {
     if client.is_none() {
-        return Err(anyhow!("kube::Client was not initialized properly")).map(cached::Return::new);
+        return Err(anyhow!("kube::Client was not initialized properly")).map(Return::new);
     }
 
     client
@@ -183,25 +185,21 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
             since,
         )
         .await
-        .map(cached::Return::new)
+        .map(Return::new)
 }
 
 pub(crate) async fn can_i(
     client: Option<&mut Client>,
     request: KWSubjectAccessReview,
-) -> Result<cached::Return<SubjectAccessReviewStatus>> {
+) -> Result<Return<SubjectAccessReviewStatus>> {
     if client.is_none() {
         return Err(anyhow!("kube::Client was not initialized properly"));
     }
 
-    client
-        .unwrap()
-        .can_i(request)
-        .await
-        .map(|value| cached::Return {
-            was_cached: false,
-            value,
-        })
+    client.unwrap().can_i(request).await.map(|value| Return {
+        was_cached: false,
+        value,
+    })
 }
 
 // A query to the Kubernetes API server is slow. This cache keeps the SubjectAccessReview
@@ -222,14 +220,14 @@ static CAN_I_CACHE: LazyLock<
 pub(crate) async fn can_i_cached(
     client: Option<&mut Client>,
     request: KWSubjectAccessReview,
-) -> Result<cached::Return<SubjectAccessReviewStatus>> {
+) -> Result<Return<SubjectAccessReviewStatus>> {
     let entry = CAN_I_CACHE
         .entry(request.clone())
         .or_try_insert_with(async { can_i(client, request).await.map(|response| response.value) })
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })

--- a/crates/policy-evaluator/src/callback_handler/kubernetes.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeSet;
-use std::sync::LazyLock;
-use std::time::Duration;
 
 mod client;
 pub(crate) mod field_mask;
@@ -29,7 +27,7 @@ pub(crate) struct KubeResource {
 }
 
 pub(crate) async fn list_resources_by_namespace(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
     namespace: &str,
@@ -56,7 +54,7 @@ pub(crate) async fn list_resources_by_namespace(
 }
 
 pub(crate) async fn list_resources_all(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
     label_selector: Option<String>,
@@ -81,7 +79,7 @@ pub(crate) async fn list_resources_all(
 }
 
 pub(crate) async fn get_resource(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
     name: &str,
@@ -101,45 +99,25 @@ pub(crate) async fn get_resource(
         })
 }
 
-// A query to the Kubernetes API server is slow. This cache keeps the resource results,
-// which are full Kubernetes objects.
-// This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the resource identity: API version, kind, name, and namespace.
-// Only successful results enter the cache.
-static GET_RESOURCE_CACHE: LazyLock<moka::future::Cache<String, kube::core::DynamicObject>> =
-    LazyLock::new(|| {
-        moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(5))
-            .build()
-    });
-
 pub(crate) async fn get_resource_cached(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
     name: &str,
     namespace: Option<&str>,
 ) -> Result<Return<kube::core::DynamicObject>> {
-    let key = format!("get_resource_cached({api_version},{kind}),{name},{namespace:?}");
-    let entry = GET_RESOURCE_CACHE
-        .entry(key)
-        .or_try_insert_with(async {
-            get_resource(client, api_version, kind, name, namespace)
+    match client {
+        Some(client) => {
+            client
+                .get_resource_cached(api_version, kind, name, namespace)
                 .await
-                .map(|response| response.value)
-        })
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+        }
+        None => Err(anyhow!("kube::Client was not initialized properly")),
+    }
 }
 
 pub(crate) async fn get_resource_plural_name(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
 ) -> Result<Return<String>> {
@@ -162,7 +140,7 @@ pub(crate) async fn get_resource_plural_name(
 /// Check if the results of the "list all resources" query have changed since the provided instant
 /// This is done by querying the reflector that keeps track of this query
 pub(crate) async fn has_list_resources_all_result_changed_since_instant(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     api_version: &str,
     kind: &str,
     label_selector: Option<String>,
@@ -189,7 +167,7 @@ pub(crate) async fn has_list_resources_all_result_changed_since_instant(
 }
 
 pub(crate) async fn can_i(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     request: KWSubjectAccessReview,
 ) -> Result<Return<SubjectAccessReviewStatus>> {
     if client.is_none() {
@@ -202,35 +180,14 @@ pub(crate) async fn can_i(
     })
 }
 
-// A query to the Kubernetes API server is slow. This cache keeps the SubjectAccessReview
-// results.
-// This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the full SubjectAccessReview request, because the type implements the Hash and
-// Eq traits.
-// Only successful results enter the cache.
-static CAN_I_CACHE: LazyLock<
-    moka::future::Cache<KWSubjectAccessReview, SubjectAccessReviewStatus>,
-> = LazyLock::new(|| {
-    moka::future::Cache::builder()
-        .time_to_live(Duration::from_secs(5))
-        .build()
-});
-
 pub(crate) async fn can_i_cached(
-    client: Option<&mut Client>,
+    client: Option<&Client>,
     request: KWSubjectAccessReview,
 ) -> Result<Return<SubjectAccessReviewStatus>> {
-    let entry = CAN_I_CACHE
-        .entry(request.clone())
-        .or_try_insert_with(async { can_i(client, request).await.map(|response| response.value) })
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    match client {
+        Some(client) => client.can_i_cached(request).await,
+        None => Err(anyhow!("kube::Client was not initialized properly")),
+    }
 }
 
 #[cfg(test)]
@@ -274,18 +231,16 @@ mod tests {
             }
         });
 
-        let mut client = Client::new(kube::Client::new(mocksvc, "default"));
+        let client = Client::new(kube::Client::new(mocksvc, "default"));
         let request = KWSubjectAccessReview {
-            // unique user name. This keeps the cache key separate from the keys of the other tests,
-            // because the cache is one process-wide static.
             user: "system:serviceaccount:default:can-i-cached-dedup-test".to_owned(),
             ..Default::default()
         };
 
-        let first = can_i_cached(Some(&mut client), request.clone())
+        let first = can_i_cached(Some(&client), request.clone())
             .await
             .expect("first call failed");
-        let second = can_i_cached(Some(&mut client), request)
+        let second = can_i_cached(Some(&client), request)
             .await
             .expect("second call failed");
 

--- a/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
+++ b/crates/policy-evaluator/src/callback_handler/kubernetes/client.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{Result, anyhow};
@@ -13,6 +14,7 @@ use kube::{
 use kubewarden_policy_sdk::host_capabilities::kubernetes::SubjectAccessReview as KWSubjectAccessReview;
 use tokio::{sync::RwLock, time::Instant};
 
+use crate::callback_handler::cache_return::{Return, try_cached};
 use crate::callback_handler::kubernetes::{ApiVersionKind, KubeResource, reflector::Reflector};
 
 #[derive(Clone)]
@@ -20,6 +22,21 @@ pub(crate) struct Client {
     kube_client: kube::Client,
     kube_resources: Arc<RwLock<HashMap<ApiVersionKind, KubeResource>>>,
     reflectors: Arc<RwLock<HashMap<String, Reflector>>>,
+    // A query to the Kubernetes API server is slow. This cache keeps the resource results,
+    // which are full Kubernetes objects.
+    // This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the resource identity: API version, kind, name, and namespace.
+    // Only successful results enter the cache.
+    get_resource_cache: moka::future::Cache<String, DynamicObject>,
+    // A query to the Kubernetes API server is slow. This cache keeps the SubjectAccessReview
+    // results.
+    // This cache is time bound. moka removes entries 5 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the full SubjectAccessReview request, because the type implements the Hash and
+    // Eq traits.
+    // Only successful results enter the cache.
+    can_i_cache: moka::future::Cache<KWSubjectAccessReview, SubjectAccessReviewStatus>,
 }
 
 impl Client {
@@ -28,13 +45,19 @@ impl Client {
             kube_client: client,
             kube_resources: Arc::new(RwLock::new(HashMap::new())),
             reflectors: Arc::new(RwLock::new(HashMap::new())),
+            get_resource_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            can_i_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
         }
     }
 
     /// Build a KubeResource using the apiVersion and Kind "coordinates" provided.
     /// The result is then cached locally to avoid further interactions with
     /// the Kubernetes API Server
-    async fn build_kube_resource(&mut self, api_version: &str, kind: &str) -> Result<KubeResource> {
+    async fn build_kube_resource(&self, api_version: &str, kind: &str) -> Result<KubeResource> {
         let avk = ApiVersionKind {
             api_version: api_version.to_owned(),
             kind: kind.to_owned(),
@@ -97,7 +120,7 @@ impl Client {
     }
 
     async fn get_reflector_reader(
-        &mut self,
+        &self,
         reflector_id: &str,
         resource: KubeResource,
         namespace: Option<String>,
@@ -135,7 +158,7 @@ impl Client {
     }
 
     pub async fn list_resources_by_namespace(
-        &mut self,
+        &self,
         api_version: &str,
         kind: &str,
         namespace: &str,
@@ -161,7 +184,7 @@ impl Client {
     }
 
     pub async fn list_resources_all(
-        &mut self,
+        &self,
         api_version: &str,
         kind: &str,
         label_selector: Option<String>,
@@ -181,7 +204,7 @@ impl Client {
     }
 
     pub async fn has_list_resources_all_result_changed_since_instant(
-        &mut self,
+        &self,
         api_version: &str,
         kind: &str,
         label_selector: Option<String>,
@@ -204,7 +227,7 @@ impl Client {
     }
 
     async fn list_resources_from_reflector(
-        &mut self,
+        &self,
         resource: KubeResource,
         namespace: Option<String>,
         label_selector: Option<String>,
@@ -249,7 +272,7 @@ impl Client {
 
     /// Check if the resources cached by the reflector have changed since the provided instant
     async fn have_reflector_resources_changed_since(
-        &mut self,
+        &self,
         resource: &KubeResource,
         namespace: Option<String>,
         label_selector: Option<String>,
@@ -277,7 +300,7 @@ impl Client {
     }
 
     pub async fn get_resource(
-        &mut self,
+        &self,
         api_version: &str,
         kind: &str,
         name: &str,
@@ -309,19 +332,12 @@ impl Client {
             .ok_or_else(|| anyhow!("Cannot find {api_version}/{kind} named '{name}' inside of namespace '{namespace:?}'"))
     }
 
-    pub async fn get_resource_plural_name(
-        &mut self,
-        api_version: &str,
-        kind: &str,
-    ) -> Result<String> {
+    pub async fn get_resource_plural_name(&self, api_version: &str, kind: &str) -> Result<String> {
         let resource = self.build_kube_resource(api_version, kind).await?;
         Ok(resource.resource.plural)
     }
 
-    pub async fn can_i(
-        &mut self,
-        request: KWSubjectAccessReview,
-    ) -> Result<SubjectAccessReviewStatus> {
+    pub async fn can_i(&self, request: KWSubjectAccessReview) -> Result<SubjectAccessReviewStatus> {
         let subject_access_review = SubjectAccessReview {
             spec: request.into(),
             ..Default::default()
@@ -336,5 +352,28 @@ impl Client {
                 .status
                 .ok_or(anyhow!("SubjectAccessReview did not return a response"))
         })
+    }
+
+    pub async fn get_resource_cached(
+        &self,
+        api_version: &str,
+        kind: &str,
+        name: &str,
+        namespace: Option<&str>,
+    ) -> Result<Return<kube::core::DynamicObject>> {
+        let key = format!("get_resource_cached({api_version},{kind}),{name},{namespace:?}");
+        try_cached(
+            &self.get_resource_cache,
+            key,
+            self.get_resource(api_version, kind, name, namespace),
+        )
+        .await
+    }
+
+    pub async fn can_i_cached(
+        &self,
+        request: KWSubjectAccessReview,
+    ) -> Result<Return<SubjectAccessReviewStatus>> {
+        try_cached(&self.can_i_cache, request.clone(), self.can_i(request)).await
     }
 }

--- a/crates/policy-evaluator/src/callback_handler/oci.rs
+++ b/crates/policy-evaluator/src/callback_handler/oci.rs
@@ -1,9 +1,8 @@
-use std::sync::LazyLock;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
-use crate::callback_handler::cache_return::Return;
+use crate::callback_handler::cache_return::{Return, try_cached};
 use kubewarden_policy_sdk::host_capabilities::oci::ManifestDigestResponse;
 use policy_fetcher::{
     oci_client::{
@@ -19,6 +18,25 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct Client {
     sources: Option<Sources>,
     registry: Registry,
+    // A query to a remote OCI registry is slow. This cache keeps the digest results.
+    // This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the image reference.
+    // Only successful results enter the cache.
+    digest_cache: moka::future::Cache<String, ManifestDigestResponse>,
+    // A query to a remote OCI registry is slow. This cache keeps the manifest results.
+    // This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the image reference.
+    // Only successful results enter the cache.
+    manifest_cache: moka::future::Cache<String, OciManifest>,
+    // A query to a remote OCI registry is slow. This cache keeps the manifest and configuration
+    // results.
+    // This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the image reference.
+    // Only successful results enter the cache.
+    manifest_and_config_cache: moka::future::Cache<String, ManifestAndConfigResponse>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -31,7 +49,19 @@ pub struct ManifestAndConfigResponse {
 impl Client {
     pub fn new(sources: Option<Sources>) -> Self {
         let registry = Registry {};
-        Client { sources, registry }
+        Client {
+            sources,
+            registry,
+            digest_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .build(),
+            manifest_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .build(),
+            manifest_and_config_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .build(),
+        }
     }
 
     /// Fetch the manifest digest of the OCI resource referenced via `image`
@@ -79,96 +109,39 @@ impl Client {
     }
 }
 
-// A query to a remote OCI registry is slow. This cache keeps the digest results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image reference. The client is not part of the key, because the client is
-// always the same.
-// Only successful results enter the cache.
-static OCI_DIGEST_CACHE: LazyLock<moka::future::Cache<String, ManifestDigestResponse>> =
-    LazyLock::new(|| {
-        moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(60))
-            .build()
-    });
-
 pub(crate) async fn get_oci_digest_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<Return<ManifestDigestResponse>> {
-    let entry = OCI_DIGEST_CACHE
-        .entry(img.to_owned())
-        .or_try_insert_with(async {
-            oci_client
-                .digest(img)
-                .await
-                .map(|digest| ManifestDigestResponse { digest })
-        })
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
+    try_cached(&oci_client.digest_cache, img.to_owned(), async {
+        oci_client
+            .digest(img)
+            .await
+            .map(|digest| ManifestDigestResponse { digest })
     })
+    .await
 }
-
-// A query to a remote OCI registry is slow. This cache keeps the manifest results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image reference. The client is not part of the key, because the client is
-// always the same.
-// Only successful results enter the cache.
-static OCI_MANIFEST_CACHE: LazyLock<moka::future::Cache<String, OciManifest>> =
-    LazyLock::new(|| {
-        moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(60))
-            .build()
-    });
 
 pub(crate) async fn get_oci_manifest_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<Return<OciManifest>> {
-    let entry = OCI_MANIFEST_CACHE
-        .entry(img.to_owned())
-        .or_try_insert_with(oci_client.manifest(img))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &oci_client.manifest_cache,
+        img.to_owned(),
+        oci_client.manifest(img),
+    )
+    .await
 }
-
-// A query to a remote OCI registry is slow. This cache keeps the manifest and configuration
-// results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image reference. The client is not part of the key, because the client is
-// always the same.
-// Only successful results enter the cache.
-static OCI_MANIFEST_AND_CONFIG_CACHE: LazyLock<
-    moka::future::Cache<String, ManifestAndConfigResponse>,
-> = LazyLock::new(|| {
-    moka::future::Cache::builder()
-        .time_to_live(Duration::from_secs(60))
-        .build()
-});
 
 pub(crate) async fn get_oci_manifest_and_config_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<Return<ManifestAndConfigResponse>> {
-    let entry = OCI_MANIFEST_AND_CONFIG_CACHE
-        .entry(img.to_owned())
-        .or_try_insert_with(oci_client.manifest_and_config(img))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &oci_client.manifest_and_config_cache,
+        img.to_owned(),
+        oci_client.manifest_and_config(img),
+    )
+    .await
 }

--- a/crates/policy-evaluator/src/callback_handler/oci.rs
+++ b/crates/policy-evaluator/src/callback_handler/oci.rs
@@ -2,6 +2,8 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
+
+use crate::callback_handler::cache_return::Return;
 use kubewarden_policy_sdk::host_capabilities::oci::ManifestDigestResponse;
 use policy_fetcher::{
     oci_client::{
@@ -93,7 +95,7 @@ static OCI_DIGEST_CACHE: LazyLock<moka::future::Cache<String, ManifestDigestResp
 pub(crate) async fn get_oci_digest_cached(
     oci_client: &Client,
     img: &str,
-) -> Result<cached::Return<ManifestDigestResponse>> {
+) -> Result<Return<ManifestDigestResponse>> {
     let entry = OCI_DIGEST_CACHE
         .entry(img.to_owned())
         .or_try_insert_with(async {
@@ -105,7 +107,7 @@ pub(crate) async fn get_oci_digest_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -127,14 +129,14 @@ static OCI_MANIFEST_CACHE: LazyLock<moka::future::Cache<String, OciManifest>> =
 pub(crate) async fn get_oci_manifest_cached(
     oci_client: &Client,
     img: &str,
-) -> Result<cached::Return<OciManifest>> {
+) -> Result<Return<OciManifest>> {
     let entry = OCI_MANIFEST_CACHE
         .entry(img.to_owned())
         .or_try_insert_with(oci_client.manifest(img))
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -158,14 +160,14 @@ static OCI_MANIFEST_AND_CONFIG_CACHE: LazyLock<
 pub(crate) async fn get_oci_manifest_and_config_cached(
     oci_client: &Client,
     img: &str,
-) -> Result<cached::Return<ManifestAndConfigResponse>> {
+) -> Result<Return<ManifestAndConfigResponse>> {
     let entry = OCI_MANIFEST_AND_CONFIG_CACHE
         .entry(img.to_owned())
         .or_try_insert_with(oci_client.manifest_and_config(img))
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })

--- a/crates/policy-evaluator/src/callback_handler/oci.rs
+++ b/crates/policy-evaluator/src/callback_handler/oci.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
-use cached::macros::cached;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
 use kubewarden_policy_sdk::host_capabilities::oci::ManifestDigestResponse;
 use policy_fetcher::{
     oci_client::{
@@ -75,69 +77,96 @@ impl Client {
     }
 }
 
-// Interacting with a remote OCI registry is time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
-//
-// Details about this cache:
-//   * only the image "url" is used as key. oci::Client is not hashable, plus
-//     the client is always the same
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
+// A query to a remote OCI registry is slow. This cache keeps the digest results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image reference. The client is not part of the key, because the client is
+// always the same.
+// Only successful results enter the cache.
+static OCI_DIGEST_CACHE: LazyLock<moka::future::Cache<String, ManifestDigestResponse>> =
+    LazyLock::new(|| {
+        moka::future::Cache::builder()
+            .time_to_live(Duration::from_secs(60))
+            .build()
+    });
+
 pub(crate) async fn get_oci_digest_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<ManifestDigestResponse>> {
-    oci_client
-        .digest(img)
+    let entry = OCI_DIGEST_CACHE
+        .entry(img.to_owned())
+        .or_try_insert_with(async {
+            oci_client
+                .digest(img)
+                .await
+                .map(|digest| ManifestDigestResponse { digest })
+        })
         .await
-        .map(|digest| ManifestDigestResponse { digest })
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
-// Interacting with a remote OCI registry is time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the manifest results.
-//
-// Details about this cache:
-//   * only the image "url" is used as key. oci::Client is not hashable, plus
-//     the client is always the same
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
+// A query to a remote OCI registry is slow. This cache keeps the manifest results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image reference. The client is not part of the key, because the client is
+// always the same.
+// Only successful results enter the cache.
+static OCI_MANIFEST_CACHE: LazyLock<moka::future::Cache<String, OciManifest>> =
+    LazyLock::new(|| {
+        moka::future::Cache::builder()
+            .time_to_live(Duration::from_secs(60))
+            .build()
+    });
+
 pub(crate) async fn get_oci_manifest_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<OciManifest>> {
-    oci_client.manifest(img).await.map(cached::Return::new)
+    let entry = OCI_MANIFEST_CACHE
+        .entry(img.to_owned())
+        .or_try_insert_with(oci_client.manifest(img))
+        .await
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", img) }"#,
-    with_cached_flag = true
-)]
+// A query to a remote OCI registry is slow. This cache keeps the manifest and configuration
+// results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image reference. The client is not part of the key, because the client is
+// always the same.
+// Only successful results enter the cache.
+static OCI_MANIFEST_AND_CONFIG_CACHE: LazyLock<
+    moka::future::Cache<String, ManifestAndConfigResponse>,
+> = LazyLock::new(|| {
+    moka::future::Cache::builder()
+        .time_to_live(Duration::from_secs(60))
+        .build()
+});
+
 pub(crate) async fn get_oci_manifest_and_config_cached(
     oci_client: &Client,
     img: &str,
 ) -> Result<cached::Return<ManifestAndConfigResponse>> {
-    oci_client
-        .manifest_and_config(img)
+    let entry = OCI_MANIFEST_AND_CONFIG_CACHE
+        .entry(img.to_owned())
+        .or_try_insert_with(oci_client.manifest_and_config(img))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }

--- a/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
+++ b/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
@@ -77,9 +77,8 @@ impl Client {
     ) -> Result<sigstore::cosign::Client> {
         let client_config: sigstore::registry::ClientConfig = sources.unwrap_or_default().into();
 
-        let mut cosign_client_builder = sigstore::cosign::ClientBuilder::default()
-            .with_oci_client_config(client_config)
-            .enable_registry_caching();
+        let mut cosign_client_builder =
+            sigstore::cosign::ClientBuilder::default().with_oci_client_config(client_config);
         let cosign_client = match trust_root {
             Some(trust_root) => {
                 cosign_client_builder =

--- a/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
+++ b/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
@@ -1,8 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc, sync::LazyLock, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use anyhow::{Result, anyhow};
 
-use crate::callback_handler::cache_return::Return;
+use crate::callback_handler::cache_return::{Return, try_cached};
 use itertools::Itertools;
 use kubewarden_policy_sdk::host_capabilities::verification::{
     KeylessInfo, KeylessPrefixInfo, VerificationResponse,
@@ -26,10 +26,28 @@ use sigstore::{
 use tokio::sync::Mutex;
 use tracing::warn;
 
+// Builds one time-bound verification cache.
+fn new_verification_cache() -> moka::future::Cache<String, VerificationResponse> {
+    moka::future::Cache::builder()
+        .time_to_live(Duration::from_secs(60))
+        .build()
+}
+
 #[derive(Clone)]
 pub(crate) struct Client {
     cosign_client: Arc<Mutex<sigstore::cosign::Client>>,
     verifier: Verifier,
+    // A sigstore verification is slow. These caches keep the verification results.
+    // They are time bound: moka removes entries 60 seconds after insertion, thus the memory
+    // usage follows the current request rate (issue #1950).
+    // The key is the image plus the verification parameters, because these values select the
+    // verification result.
+    // Only successful results enter the cache.
+    pub_key_verification_cache: moka::future::Cache<String, VerificationResponse>,
+    keyless_verification_cache: moka::future::Cache<String, VerificationResponse>,
+    keyless_prefix_verification_cache: moka::future::Cache<String, VerificationResponse>,
+    github_actions_verification_cache: moka::future::Cache<String, VerificationResponse>,
+    certificate_verification_cache: moka::future::Cache<String, VerificationResponse>,
 }
 
 impl Client {
@@ -45,6 +63,11 @@ impl Client {
         Ok(Client {
             cosign_client,
             verifier,
+            pub_key_verification_cache: new_verification_cache(),
+            keyless_verification_cache: new_verification_cache(),
+            keyless_prefix_verification_cache: new_verification_cache(),
+            github_actions_verification_cache: new_verification_cache(),
+            certificate_verification_cache: new_verification_cache(),
         })
     }
 
@@ -79,7 +102,7 @@ impl Client {
     }
 
     pub async fn verify_public_key(
-        &mut self,
+        &self,
         image: String,
         pub_keys: Vec<String>,
         annotations: Option<BTreeMap<String, String>>,
@@ -112,7 +135,7 @@ impl Client {
     }
 
     pub async fn verify_keyless(
-        &mut self,
+        &self,
         image: String,
         keyless: Vec<KeylessInfo>,
         annotations: Option<BTreeMap<String, String>>,
@@ -147,7 +170,7 @@ impl Client {
     }
 
     pub async fn verify_keyless_prefix(
-        &mut self,
+        &self,
         image: String,
         keyless_prefix: Vec<KeylessPrefixInfo>,
         annotations: Option<BTreeMap<String, String>>,
@@ -183,7 +206,7 @@ impl Client {
     }
 
     pub async fn verify_github_actions(
-        &mut self,
+        &self,
         image: String,
         owner: String,
         repo: Option<String>,
@@ -217,7 +240,7 @@ impl Client {
     }
 
     pub async fn verify_certificate(
-        &mut self,
+        &self,
         image: &str,
         certificate: &[u8],
         certificate_chain: Option<&[Vec<u8>]>,
@@ -259,126 +282,65 @@ impl Client {
     }
 }
 
-// Builds one time-bound verification cache.
-fn new_verification_cache() -> moka::future::Cache<String, VerificationResponse> {
-    moka::future::Cache::builder()
-        .time_to_live(Duration::from_secs(60))
-        .build()
-}
-
-// A sigstore verification is slow. This cache keeps the verification results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image plus the verification parameters, because these values select the
-// verification result.
-// Only successful results enter the cache.
-static PUB_KEY_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
-    LazyLock::new(new_verification_cache);
-
 pub(crate) async fn get_sigstore_pub_key_verification_cached(
-    client: &mut Client,
+    client: &Client,
     image: String,
     pub_keys: Vec<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{pub_keys:?}{annotations:?}");
-    let entry = PUB_KEY_VERIFICATION_CACHE
-        .entry(key)
-        .or_try_insert_with(client.verify_public_key(image, pub_keys, annotations))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &client.pub_key_verification_cache,
+        key,
+        client.verify_public_key(image, pub_keys, annotations),
+    )
+    .await
 }
 
-// A sigstore verification is slow. This cache keeps the verification results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image plus the verification parameters, because these values select the
-// verification result.
-// Only successful results enter the cache.
-static KEYLESS_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
-    LazyLock::new(new_verification_cache);
-
 pub(crate) async fn get_sigstore_keyless_verification_cached(
-    client: &mut Client,
+    client: &Client,
     image: String,
     keyless: Vec<KeylessInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{keyless:?}{annotations:?}");
-    let entry = KEYLESS_VERIFICATION_CACHE
-        .entry(key)
-        .or_try_insert_with(client.verify_keyless(image, keyless, annotations))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &client.keyless_verification_cache,
+        key,
+        client.verify_keyless(image, keyless, annotations),
+    )
+    .await
 }
 
-// A sigstore verification is slow. This cache keeps the verification results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image plus the verification parameters, because these values select the
-// verification result.
-// Only successful results enter the cache.
-static KEYLESS_PREFIX_VERIFICATION_CACHE: LazyLock<
-    moka::future::Cache<String, VerificationResponse>,
-> = LazyLock::new(new_verification_cache);
-
 pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
-    client: &mut Client,
+    client: &Client,
     image: String,
     keyless_prefix: Vec<KeylessPrefixInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{keyless_prefix:?}{annotations:?}");
-    let entry = KEYLESS_PREFIX_VERIFICATION_CACHE
-        .entry(key)
-        .or_try_insert_with(client.verify_keyless_prefix(image, keyless_prefix, annotations))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &client.keyless_prefix_verification_cache,
+        key,
+        client.verify_keyless_prefix(image, keyless_prefix, annotations),
+    )
+    .await
 }
 
-// A sigstore verification is slow. This cache keeps the verification results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image plus the verification parameters, because these values select the
-// verification result.
-// Only successful results enter the cache.
-static GITHUB_ACTIONS_VERIFICATION_CACHE: LazyLock<
-    moka::future::Cache<String, VerificationResponse>,
-> = LazyLock::new(new_verification_cache);
-
 pub(crate) async fn get_sigstore_github_actions_verification_cached(
-    client: &mut Client,
+    client: &Client,
     image: String,
     owner: String,
     repo: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{owner:?}{repo:?}{annotations:?}");
-    let entry = GITHUB_ACTIONS_VERIFICATION_CACHE
-        .entry(key)
-        .or_try_insert_with(client.verify_github_actions(image, owner, repo, annotations))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+    try_cached(
+        &client.github_actions_verification_cache,
+        key,
+        client.verify_github_actions(image, owner, repo, annotations),
+    )
+    .await
 }
 
 fn get_sigstore_certificate_verification_cache_key(
@@ -416,17 +378,8 @@ fn get_sigstore_certificate_verification_cache_key(
     hex::encode(hasher.finalize())
 }
 
-// A sigstore verification is slow. This cache keeps the verification results.
-// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
-// usage follows the current request rate (issue #1950).
-// The key is the image plus the verification parameters, because these values select the
-// verification result.
-// Only successful results enter the cache.
-static CERTIFICATE_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
-    LazyLock::new(new_verification_cache);
-
 pub(crate) async fn get_sigstore_certificate_verification_cached(
-    client: &mut Client,
+    client: &Client,
     image: &str,
     certificate: &[u8],
     certificate_chain: Option<&[Vec<u8>]>,
@@ -440,20 +393,16 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
         require_rekor_bundle,
         annotations.as_ref(),
     );
-    let entry = CERTIFICATE_VERIFICATION_CACHE
-        .entry(key)
-        .or_try_insert_with(client.verify_certificate(
+    try_cached(
+        &client.certificate_verification_cache,
+        key,
+        client.verify_certificate(
             image,
             certificate,
             certificate_chain,
             require_rekor_bundle,
             annotations,
-        ))
-        .await
-        .map_err(|e| anyhow!("{e:#}"))?;
-
-    Ok(Return {
-        was_cached: !entry.is_fresh(),
-        value: entry.into_value(),
-    })
+        ),
+    )
+    .await
 }

--- a/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
+++ b/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
@@ -1,6 +1,8 @@
 use std::{collections::BTreeMap, sync::Arc, sync::LazyLock, time::Duration};
 
 use anyhow::{Result, anyhow};
+
+use crate::callback_handler::cache_return::Return;
 use itertools::Itertools;
 use kubewarden_policy_sdk::host_capabilities::verification::{
     KeylessInfo, KeylessPrefixInfo, VerificationResponse,
@@ -278,7 +280,7 @@ pub(crate) async fn get_sigstore_pub_key_verification_cached(
     image: String,
     pub_keys: Vec<String>,
     annotations: Option<BTreeMap<String, String>>,
-) -> Result<cached::Return<VerificationResponse>> {
+) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{pub_keys:?}{annotations:?}");
     let entry = PUB_KEY_VERIFICATION_CACHE
         .entry(key)
@@ -286,7 +288,7 @@ pub(crate) async fn get_sigstore_pub_key_verification_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -306,7 +308,7 @@ pub(crate) async fn get_sigstore_keyless_verification_cached(
     image: String,
     keyless: Vec<KeylessInfo>,
     annotations: Option<BTreeMap<String, String>>,
-) -> Result<cached::Return<VerificationResponse>> {
+) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{keyless:?}{annotations:?}");
     let entry = KEYLESS_VERIFICATION_CACHE
         .entry(key)
@@ -314,7 +316,7 @@ pub(crate) async fn get_sigstore_keyless_verification_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -335,7 +337,7 @@ pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
     image: String,
     keyless_prefix: Vec<KeylessPrefixInfo>,
     annotations: Option<BTreeMap<String, String>>,
-) -> Result<cached::Return<VerificationResponse>> {
+) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{keyless_prefix:?}{annotations:?}");
     let entry = KEYLESS_PREFIX_VERIFICATION_CACHE
         .entry(key)
@@ -343,7 +345,7 @@ pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -365,7 +367,7 @@ pub(crate) async fn get_sigstore_github_actions_verification_cached(
     owner: String,
     repo: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
-) -> Result<cached::Return<VerificationResponse>> {
+) -> Result<Return<VerificationResponse>> {
     let key = format!("{image}{owner:?}{repo:?}{annotations:?}");
     let entry = GITHUB_ACTIONS_VERIFICATION_CACHE
         .entry(key)
@@ -373,7 +375,7 @@ pub(crate) async fn get_sigstore_github_actions_verification_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })
@@ -430,7 +432,7 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
     certificate_chain: Option<&[Vec<u8>]>,
     require_rekor_bundle: bool,
     annotations: Option<BTreeMap<String, String>>,
-) -> Result<cached::Return<VerificationResponse>> {
+) -> Result<Return<VerificationResponse>> {
     let key = get_sigstore_certificate_verification_cache_key(
         image,
         certificate,
@@ -450,7 +452,7 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
         .await
         .map_err(|e| anyhow!("{e:#}"))?;
 
-    Ok(cached::Return {
+    Ok(Return {
         was_cached: !entry.is_fresh(),
         value: entry.into_value(),
     })

--- a/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
+++ b/crates/policy-evaluator/src/callback_handler/sigstore_verification.rs
@@ -1,7 +1,6 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, sync::LazyLock, time::Duration};
 
 use anyhow::{Result, anyhow};
-use cached::macros::cached;
 use itertools::Itertools;
 use kubewarden_policy_sdk::host_capabilities::verification::{
     KeylessInfo, KeylessPrefixInfo, VerificationResponse,
@@ -258,98 +257,108 @@ impl Client {
     }
 }
 
-// Sigstore verifications are time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
-//
-// Details about this cache:
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, pub_keys, annotations)}"#,
-    with_cached_flag = true
-)]
+// Builds one time-bound verification cache.
+fn new_verification_cache() -> moka::future::Cache<String, VerificationResponse> {
+    moka::future::Cache::builder()
+        .time_to_live(Duration::from_secs(60))
+        .build()
+}
+
+// A sigstore verification is slow. This cache keeps the verification results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image plus the verification parameters, because these values select the
+// verification result.
+// Only successful results enter the cache.
+static PUB_KEY_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
+    LazyLock::new(new_verification_cache);
+
 pub(crate) async fn get_sigstore_pub_key_verification_cached(
     client: &mut Client,
     image: String,
     pub_keys: Vec<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_public_key(image, pub_keys, annotations)
+    let key = format!("{image}{pub_keys:?}{annotations:?}");
+    let entry = PUB_KEY_VERIFICATION_CACHE
+        .entry(key)
+        .or_try_insert_with(client.verify_public_key(image, pub_keys, annotations))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
-// Sigstore verifications are time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
-//
-// Details about this cache:
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, keyless, annotations)}"#,
-    with_cached_flag = true
-)]
+// A sigstore verification is slow. This cache keeps the verification results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image plus the verification parameters, because these values select the
+// verification result.
+// Only successful results enter the cache.
+static KEYLESS_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
+    LazyLock::new(new_verification_cache);
+
 pub(crate) async fn get_sigstore_keyless_verification_cached(
     client: &mut Client,
     image: String,
     keyless: Vec<KeylessInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_keyless(image, keyless, annotations)
+    let key = format!("{image}{keyless:?}{annotations:?}");
+    let entry = KEYLESS_VERIFICATION_CACHE
+        .entry(key)
+        .or_try_insert_with(client.verify_keyless(image, keyless, annotations))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
-// Sigstore verifications are time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
-//
-// Details about this cache:
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}", image, keyless_prefix, annotations)}"#,
-    with_cached_flag = true
-)]
+// A sigstore verification is slow. This cache keeps the verification results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image plus the verification parameters, because these values select the
+// verification result.
+// Only successful results enter the cache.
+static KEYLESS_PREFIX_VERIFICATION_CACHE: LazyLock<
+    moka::future::Cache<String, VerificationResponse>,
+> = LazyLock::new(new_verification_cache);
+
 pub(crate) async fn get_sigstore_keyless_prefix_verification_cached(
     client: &mut Client,
     image: String,
     keyless_prefix: Vec<KeylessPrefixInfo>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_keyless_prefix(image, keyless_prefix, annotations)
+    let key = format!("{image}{keyless_prefix:?}{annotations:?}");
+    let entry = KEYLESS_PREFIX_VERIFICATION_CACHE
+        .entry(key)
+        .or_try_insert_with(client.verify_keyless_prefix(image, keyless_prefix, annotations))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
-// Sigstore verifications are time expensive, this can cause a massive slow down
-// of policy evaluations, especially inside of PolicyServer.
-// Because of that we will keep a cache of the digests results.
-//
-// Details about this cache:
-//   * the cache is time bound: cached values are purged after 60 seconds
-//   * only successful results are cached
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}{:?}{:?}{:?}", image, owner, repo, annotations)}"#,
-    with_cached_flag = true
-)]
+// A sigstore verification is slow. This cache keeps the verification results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image plus the verification parameters, because these values select the
+// verification result.
+// Only successful results enter the cache.
+static GITHUB_ACTIONS_VERIFICATION_CACHE: LazyLock<
+    moka::future::Cache<String, VerificationResponse>,
+> = LazyLock::new(new_verification_cache);
+
 pub(crate) async fn get_sigstore_github_actions_verification_cached(
     client: &mut Client,
     image: String,
@@ -357,10 +366,17 @@ pub(crate) async fn get_sigstore_github_actions_verification_cached(
     repo: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_github_actions(image, owner, repo, annotations)
+    let key = format!("{image}{owner:?}{repo:?}{annotations:?}");
+    let entry = GITHUB_ACTIONS_VERIFICATION_CACHE
+        .entry(key)
+        .or_try_insert_with(client.verify_github_actions(image, owner, repo, annotations))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }
 
 fn get_sigstore_certificate_verification_cache_key(
@@ -398,13 +414,15 @@ fn get_sigstore_certificate_verification_cache_key(
     hex::encode(hasher.finalize())
 }
 
-#[cached(
-    ttl = 60,
-    sync_writes = "default",
-    key = "String",
-    convert = r#"{ format!("{}", get_sigstore_certificate_verification_cache_key(image, certificate, certificate_chain, require_rekor_bundle, annotations.as_ref()))}"#,
-    with_cached_flag = true
-)]
+// A sigstore verification is slow. This cache keeps the verification results.
+// This cache is time bound. moka removes entries 60 seconds after insertion, thus the memory
+// usage follows the current request rate (issue #1950).
+// The key is the image plus the verification parameters, because these values select the
+// verification result.
+// Only successful results enter the cache.
+static CERTIFICATE_VERIFICATION_CACHE: LazyLock<moka::future::Cache<String, VerificationResponse>> =
+    LazyLock::new(new_verification_cache);
+
 pub(crate) async fn get_sigstore_certificate_verification_cached(
     client: &mut Client,
     image: &str,
@@ -413,14 +431,27 @@ pub(crate) async fn get_sigstore_certificate_verification_cached(
     require_rekor_bundle: bool,
     annotations: Option<BTreeMap<String, String>>,
 ) -> Result<cached::Return<VerificationResponse>> {
-    client
-        .verify_certificate(
+    let key = get_sigstore_certificate_verification_cache_key(
+        image,
+        certificate,
+        certificate_chain,
+        require_rekor_bundle,
+        annotations.as_ref(),
+    );
+    let entry = CERTIFICATE_VERIFICATION_CACHE
+        .entry(key)
+        .or_try_insert_with(client.verify_certificate(
             image,
             certificate,
             certificate_chain,
             require_rekor_bundle,
             annotations,
-        )
+        ))
         .await
-        .map(cached::Return::new)
+        .map_err(|e| anyhow!("{e:#}"))?;
+
+    Ok(cached::Return {
+        was_cached: !entry.is_fresh(),
+        value: entry.into_value(),
+    })
 }

--- a/crates/policy-fetcher/Cargo.toml
+++ b/crates/policy-fetcher/Cargo.toml
@@ -36,7 +36,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 sigstore = { version = "0.14", default-features = false, features = [
-  "cached-client",
   "cosign",
   "rustls-tls",
   "sigstore-trust-root",

--- a/crates/policy-fetcher/src/verify/mod.rs
+++ b/crates/policy-fetcher/src/verify/mod.rs
@@ -94,7 +94,7 @@ impl Verifier {
     /// Note well: right now, verification can be done only against policies
     /// that are stored inside of OCI registries.
     pub async fn verify(
-        &mut self,
+        &self,
         image_url: &str,
         verification_config: &config::LatestVerificationConfig,
     ) -> VerifyResult<String> {
@@ -120,7 +120,7 @@ impl Verifier {
     /// Note well: right now, verification can be done only against policies
     /// that are stored inside of OCI registries.
     pub async fn verify_local_file_checksum(
-        &mut self,
+        &self,
         policy: &Policy,
         verified_manifest_digest: &str,
     ) -> VerifyResult<()> {

--- a/crates/policy-fetcher/src/verify/mod.rs
+++ b/crates/policy-fetcher/src/verify/mod.rs
@@ -54,9 +54,8 @@ impl Verifier {
     ) -> VerifyResult<Self> {
         let client_config: sigstore::registry::ClientConfig =
             sources.clone().unwrap_or_default().into();
-        let mut cosign_client_builder = ClientBuilder::default()
-            .with_oci_client_config(client_config)
-            .enable_registry_caching();
+        let mut cosign_client_builder =
+            ClientBuilder::default().with_oci_client_config(client_config);
         let cosign_client = match trust_root {
             Some(trust_root) => {
                 cosign_client_builder =

--- a/crates/policy-server/src/policy_downloader.rs
+++ b/crates/policy-server/src/policy_downloader.rs
@@ -99,7 +99,7 @@ impl Downloader {
 
             let mut verified_manifest_digest: Option<String> = None;
 
-            if let Some(ver) = self.verifier.as_mut() {
+            if let Some(ver) = self.verifier.as_ref() {
                 info!(
                     policy = name.as_str(),
                     "verifying policy authenticity and integrity using sigstore"
@@ -155,7 +155,7 @@ impl Downloader {
                 }
             };
 
-            if let Some(ver) = self.verifier.as_mut() {
+            if let Some(ver) = self.verifier.as_ref() {
                 if let Err(e) = ver
                     .verify_local_file_checksum(
                         &fetched_policy,


### PR DESCRIPTION
## Description

Fix #1950

The cached crate does not free memory when the TTL passes. It removes an expired entry only when the same key is queried again. Context-aware policies query many distinct keys, thus the caches grow without limit.

Replace the `#[cached]` macros with moka caches. moka removes expired entries during routine cache operations. As a result, the memory usage follows the current request rate, and old entries do not accumulate.
The caches have no entry-count bound. A bound is not necessary, because the TTL windows are short (5 s and 60 s) and moka removes the expired entries without a new query for the same key.

The behavior does not change:
- Only successful results enter the cache.
- Concurrent misses for the same key make one backend call.
- The was_cached flag comes from Entry::is_fresh().
- The TTL windows and the key expressions stay the same.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
No new tests are needed for the wrappers.
Added new test to see if the cache static approach is being exercised for `can_i_cached()`.

Tested locally.
Testing performance changes (see issue comments), hence why draft request. 

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

The cached macro held one global lock per cache, and a miss held this lock for the full backend call. moka uses a lock-free hash table, thus hits do not wait, and misses for different keys run in parallel. As a cost, moka does its housekeeping on the caller threads in small batches, and each entry uses more metadata bytes than a plain hash map entry.
These costs are small compared to the network round-trips of the functions we cache.

### Potential improvement

We could set entry count bound + weighted counts on moka (as we could on cached). This would make hot entries survive more. But there's no 1-size-fits-all counts per function. The best default I can think of is to put as highest default counters as possible, to ensure the cache gets exercised in big production cluster. 

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
