### PR TITLE
chore: Refresh RUSTSEC advisory list on deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ ignore = [
   { id = "RUSTSEC-2023-0071", reason = "rsa side channel attack, no fix exists yet" },
   { id = "RUSTSEC-2024-0436", reason = "paste, no longer maintained. transitive dependency" },
   { id = "RUSTSEC-2025-0069", reason = "daemonize crate is no longer maintained" },
+  { id = "RUSTSEC-2026-0249", reason = "smartstring is no longer maintained. Transitive dependency of rhai, which depends on it unconditionally, with no feature to disable it" },
 ]
 
 # If this is true, then cargo deny will use the git executable to fetch advisory database.

--- a/deny.toml
+++ b/deny.toml
@@ -71,7 +71,6 @@ ignore = [
   { id = "RUSTSEC-2023-0071", reason = "rsa side channel attack, no fix exists yet" },
   { id = "RUSTSEC-2024-0436", reason = "paste, no longer maintained. transitive dependency" },
   { id = "RUSTSEC-2025-0069", reason = "daemonize crate is no longer maintained" },
-  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is no longer maintained" },
 ]
 
 # If this is true, then cargo deny will use the git executable to fetch advisory database.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Makes the rustsec advisory CI job pass.
- chore: Drop proc-macro-error2 advisory override, not needed
- chore: Add smartstring advisory override. It is a transitive dep of rhai, we need to wait for rhai
to migrate.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->



<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
