### PR TITLE
feat(chart): Provide `artifacthub.io/images` annots in Chart.yaml

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-dependencies:
-    name: Update Go version, Helm charts dependencies and Hauler manifest
+    name: Update Go version, Helm chart dependencies, Hauler manifest, ArtifactHub annot
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -44,6 +44,23 @@ annotations:
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool
+  # List of images that the chart can deploy. Artifact Hub uses this list to
+  # link the images to the correct security report, because Artifact Hub can
+  # find only the images from a dry-run install with default values.
+  # Reference: https://artifacthub.io/docs/topics/annotations/helm/
+  artifacthub.io/images: |
+    - name: controller
+      image: ghcr.io/kubewarden/adm-controller/controller:v1.37.2
+    - name: audit-scanner
+      image: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.2
+    - name: policy-server
+      image: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2
+    - name: kuberlr-kubectl
+      image: ghcr.io/rancher/kuberlr-kubectl:v8.1.1
+    - name: policy-reporter
+      image: ghcr.io/kyverno/policy-reporter:3.9.0
+    - name: policy-reporter-ui
+      image: ghcr.io/kyverno/policy-reporter-ui:2.7.0
 dependencies:
   - name: openreports
     version: 0.2.1

--- a/updatecli/DEVELOPING.md
+++ b/updatecli/DEVELOPING.md
@@ -52,6 +52,7 @@ Updates the following dependencies:
 - Policy-reporter and openreports chart versions
 - Kuberlr-kubectl image version
 - Hauler manifest with all component versions
+- The `artifacthub.io/images` annotation in `charts/admission-controller/Chart.yaml`
 
 ### Running Updates Manually
 For manual runs of all dependency updates:

--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -134,6 +134,43 @@ targets:
       matchpattern: "(.*)- ?name: ?ghcr.io/kyverno/policy-reporter-ui:(v?.+) ?(.*)"
       replacepattern: '$1- name: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
 
+  # The following targets keep the artifacthub.io/images annotation, in
+  # charts/admission-controller/Chart.yaml, in sync with the image tags in
+  # values.yaml.
+  # {{ range $oci := .ociArtifacts }}
+  # {{ if $oci.artifactHubImage }}
+  "target/{{ $oci.image }}ArtifactHubAnnotation":
+    name: "Update {{ $oci.image }} image in artifacthub.io/images annotation"
+    kind: file
+    sourceid: "source/{{ $oci.image }}Version"
+    scmid: "default"
+    dependson:
+      - '{{ printf "source#source/%sVersion" $oci.image }}'
+    spec:
+      file: "charts/admission-controller/Chart.yaml"
+      matchpattern: "(.*)image: {{ $oci.image }}:(v?.+) ?(.*)"
+      replacepattern: '$1image: {{ $oci.image }}:{{ printf "source/%sVersion" $oci.image | source }}'
+  # {{ end }}
+  # {{ end }}
+  policyReporterArtifactHubAnnotation:
+    name: "Update policy-reporter image in artifacthub.io/images annotation"
+    kind: file
+    sourceid: policyReporterChartAppVersion
+    scmid: default
+    spec:
+      file: "charts/admission-controller/Chart.yaml"
+      matchpattern: "(.*)image: ghcr.io/kyverno/policy-reporter:(v?.+) ?(.*)"
+      replacepattern: '$1image: ghcr.io/kyverno/policy-reporter:{{ source "policyReporterChartAppVersion" }}'
+  policyReporterUIArtifactHubAnnotation:
+    name: "Update policy-reporter-ui image in artifacthub.io/images annotation"
+    kind: file
+    sourceid: policyReporterChartUIImageTagValue
+    scmid: default
+    spec:
+      file: "charts/admission-controller/Chart.yaml"
+      matchpattern: "(.*)image: ghcr.io/kyverno/policy-reporter-ui:(v?.+) ?(.*)"
+      replacepattern: '$1image: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
+
 # {{ if .pr.haulerUpdatePr }}
 actions:
   openUpdatePR:
@@ -144,7 +181,7 @@ actions:
       automerge: false
       mergemethod: squash
       description: |
-        Automatic update of Helm chart dependencies: Helm charts, policies, kuberlr-kubectl image, and Hauler manifest.
+        Automatic update of Helm chart dependencies: Helm charts, policies, kuberlr-kubectl image, Hauler manifest, and the artifacthub.io/images annotation.
         This PR has been created by automation.
 
         > [!IMPORTANT]

--- a/updatecli/values/artifacts.yaml
+++ b/updatecli/values/artifacts.yaml
@@ -7,25 +7,30 @@ ociArtifacts:
   # The workflowUrl field defined in the Kubewarden
   # container images is the url used to validate the identity with cosign
   #
-  # The skipVersionFromRegistry field defined in the Kubewarden images is a
-  # flag to skip update of the images version in the Helm chart with the
-  # version in the registry. These container image should use the container
-  # image defined in the release process
+  # - The skipVersionFromRegistry field defined in the Kubewarden images is a
+  #   flag to skip update of the images version in the Helm chart with the
+  #   version in the registry. These container images should use the container
+  # - image defined in the release process.
+  #   The artifactHubImage field marks the images that are also listed in the
+  #   artifacthub.io/images annotation, in charts/admission-controller/Chart.yaml.
   - file: "charts/admission-controller/values.yaml"
     key: "$.image.tag"
     image: "ghcr.io/kubewarden/adm-controller/controller"
     workflowUrl: "https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags"
     skipVersionFromRegistry: true
+    artifactHubImage: true
   - file: "charts/admission-controller/values.yaml"
     key: "$.auditScanner.image.tag"
     image: "ghcr.io/kubewarden/adm-controller/audit-scanner"
     workflowUrl: "https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags"
     skipVersionFromRegistry: true
+    artifactHubImage: true
   - file: "charts/admission-controller/values.yaml"
     key: "$.policyServer.image.tag"
     image: "ghcr.io/kubewarden/adm-controller/policy-server"
     workflowUrl: "https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags"
     skipVersionFromRegistry: true
+    artifactHubImage: true
   # Policies
   - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
     file: "charts/admission-controller/values.yaml"
@@ -49,6 +54,7 @@ ociArtifacts:
   - image: ghcr.io/rancher/kuberlr-kubectl
     file: "charts/admission-controller/values.yaml"
     key: "$.preDeleteJob.image.tag"
+    artifactHubImage: true
 # The helmCharts list all the Helm charts listed in the Hauler that needs to be
 # updated regularly. This list should be in the same order as defined in the
 # charts/hauler_manifest.yaml file.

--- a/updatecli/values/artifacts.yaml
+++ b/updatecli/values/artifacts.yaml
@@ -10,8 +10,8 @@ ociArtifacts:
   # - The skipVersionFromRegistry field defined in the Kubewarden images is a
   #   flag to skip update of the images version in the Helm chart with the
   #   version in the registry. These container images should use the container
-  # - image defined in the release process.
-  #   The artifactHubImage field marks the images that are also listed in the
+  #   image defined in the release process.
+  # - The artifactHubImage field marks the images that are also listed in the
   #   artifacthub.io/images annotation, in charts/admission-controller/Chart.yaml.
   - file: "charts/admission-controller/values.yaml"
     key: "$.image.tag"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/kubewarden/adm-controller/issues/1951

This annotation provides a list of all images for the vulnerability scan
of Artifact Hub.

By default, Artifact Hub obtains the images from a dry-run install with
default values, which leaves some out:
- Optional dep on policy-reporter
- kuberlr-kubectl on uninstall jobs

See https://artifacthub.io/docs/topics/annotations/helm/


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested updatecli locally by:
- Change its SCS config from `kind: github` to git
- Set `pr.haulerUpdatePr: false`
- Run`updatecli diff`

Run in my fork:
https://github.com/viccuad/adm-controller/actions/runs/33072719279


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
