### PR TITLE
fix(ci): Correctly replace artifacthub image annotations

### DIFF
--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -148,8 +148,8 @@ targets:
       - '{{ printf "source#source/%sVersion" $oci.image }}'
     spec:
       file: "charts/admission-controller/Chart.yaml"
-      matchpattern: "(.*)image: {{ $oci.image }}:(v?.+) ?(.*)"
-      replacepattern: '$1image: {{ $oci.image }}:{{ printf "source/%sVersion" $oci.image | source }}'
+      matchpattern: "image: {{ $oci.image }}:(v?\\S+)"
+      replacepattern: 'image: {{ $oci.image }}:{{ printf "source/%sVersion" $oci.image | source }}'
   # {{ end }}
   # {{ end }}
   policyReporterArtifactHubAnnotation:
@@ -159,8 +159,8 @@ targets:
     scmid: default
     spec:
       file: "charts/admission-controller/Chart.yaml"
-      matchpattern: "(.*)image: ghcr.io/kyverno/policy-reporter:(v?.+) ?(.*)"
-      replacepattern: '$1image: ghcr.io/kyverno/policy-reporter:{{ source "policyReporterChartAppVersion" }}'
+      matchpattern: "image: ghcr.io/kyverno/policy-reporter:(v?\\S+)"
+      replacepattern: 'image: ghcr.io/kyverno/policy-reporter:{{ source "policyReporterChartAppVersion" }}'
   policyReporterUIArtifactHubAnnotation:
     name: "Update policy-reporter-ui image in artifacthub.io/images annotation"
     kind: file
@@ -168,8 +168,8 @@ targets:
     scmid: default
     spec:
       file: "charts/admission-controller/Chart.yaml"
-      matchpattern: "(.*)image: ghcr.io/kyverno/policy-reporter-ui:(v?.+) ?(.*)"
-      replacepattern: '$1image: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
+      matchpattern: "image: ghcr.io/kyverno/policy-reporter-ui:(v?\\S+)"
+      replacepattern: 'image: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
 
 # {{ if .pr.haulerUpdatePr }}
 actions:

--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -159,7 +159,7 @@ targets:
     scmid: default
     spec:
       file: "charts/admission-controller/Chart.yaml"
-      matchpattern: "image: ghcr.io/kyverno/policy-reporter:(v?\\S+)"
+      matchpattern: "image: ghcr\\.io/kyverno/policy-reporter:(v?\\S+)"
       replacepattern: 'image: ghcr.io/kyverno/policy-reporter:{{ source "policyReporterChartAppVersion" }}'
   policyReporterUIArtifactHubAnnotation:
     name: "Update policy-reporter-ui image in artifacthub.io/images annotation"
@@ -168,7 +168,7 @@ targets:
     scmid: default
     spec:
       file: "charts/admission-controller/Chart.yaml"
-      matchpattern: "image: ghcr.io/kyverno/policy-reporter-ui:(v?\\S+)"
+      matchpattern: "image: ghcr\\.io/kyverno/policy-reporter-ui:(v?\\S+)"
       replacepattern: 'image: ghcr.io/kyverno/policy-reporter-ui:{{ source "policyReporterChartUIImageTagValue" }}'
 
 # {{ if .pr.haulerUpdatePr }}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Correctly replace Artifact Hub annotations in Chart.yaml.
Previously, the replace would eat the key `image` on each of the array elements, because we were using go regex groups with `$1` in `$1image`, but it should have been `${1}image`. We don't need a group there nevertheless, as it only matches whitespace.

This fixes that.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested locally by changing the git scm to local. 

Test results, with the local git-SCM method:
1. Clean case: all six *ArtifactHubAnnotation targets report "already up to date", against the annotation now in main.
2. Drift case: with kuberlr-kubectl:v8.0.0 injected, the target produced this exact patch:
```patch
-      image: ghcr.io/rancher/kuberlr-kubectl:v8.0.0
+      image: ghcr.io/rancher/kuberlr-kubectl:v8.1.1
```
Indentation and the image: prefix stay correct.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
