### PR TITLE
ci: Configure release-drafter to use PR tiles instead of PR labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,19 +1,26 @@
 categories:
   - title: "⚠️  Breaking changes"
-    labels:
-      - "kind/major"
-      - "kind/breaking-change"
+    semver-increment: "major"
+    when:
+      conventional:
+        breaking: true
   - title: "🚀 Features"
-    labels:
-      - "kind/enhancement"
-      - "kind/feature"
+    semver-increment: "minor"
+    when:
+      conventional:
+        type: "feat"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "kind/bug"
+    semver-increment: "patch"
+    when:
+      conventional:
+        type: "fix"
   - title: "🧰 Maintenance"
-    labels:
-      - "kind/chore"
-      - "area/dependencies"
+    semver-increment: "patch"
+    when:
+      conventional:
+        types: ["chore", "build", "ci", "docs", "refactor", "test"]
+  - title: "📦 Other Changes"
+    semver-increment: "patch"
 
 exclude-labels:
   - duplicate
@@ -56,22 +63,3 @@ autolabeler:
   - label: "kind/chore"
     title:
       - "chore"
-
-version-resolver:
-  major:
-    labels:
-      - "kind/major"
-      - "kind/breaking-change"
-  minor:
-    labels:
-      - "kind/minor"
-      - "kind/feature"
-      - "kind/enhancement"
-  patch:
-    labels:
-      - "kind/patch"
-      - "kind/fix"
-      - "kind/bug"
-      - "kind/chore"
-      - "area/dependencies"
-  default: patch


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/kubewarden/adm-controller/issues/1936
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

We used `autolabeler` to, from the PR title, label the PR, and then
`release-drafter` checked the PR labels to draft the GH release.
We don't allow `autolabeler` permissions to add labels for PRs coming
for forks, for security reasons. This meant we needed to label these
PRs manually.

Now, we configure `release-drafter` to read the PR title (new in
release-drafter 7.7.0) to draft the GH release.
We also add an "Other changes" section as a catch-all for all PRs.

This means we correctly add all PRs to our GH release, no matter
if they come from forks or not.

We still run `autolabeler` to label PRs automatically, same as before.

Add workflow triggers to also run release-drafter on PR edits.


## Test

<!-- Please provides a short description about how to test your pullrequest -->

Untested.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
