### PR TITLE
fix(policy-server): ignore timeoutEvalSeconds when timeout protection is disabled

### DIFF
--- a/crates/policy-server/src/config.rs
+++ b/crates/policy-server/src/config.rs
@@ -323,7 +323,10 @@ pub struct PolicyGroupMember {
     /// The list of Kubernetes resources the policy is allowed to access
     #[serde(default)]
     pub context_aware_resources: BTreeSet<ContextAwareResource>,
-    /// Timeout for the evaluation of the policy
+    /// Timeout for the evaluation of the policy. Overrides the server-wide
+    /// `policy_evaluation_limit_seconds` for this policy. Only takes effect
+    /// when timeout protection is enabled (i.e. `--disable-timeout-protection`
+    /// is not set); it is ignored otherwise.
     pub timeout_eval_seconds: Option<u64>,
     /// List of host capabilities granted to this policy
     #[serde(default)]
@@ -359,7 +362,10 @@ pub enum PolicyOrPolicyGroup {
         context_aware_resources: BTreeSet<ContextAwareResource>,
         /// The message that is returned when the policy evaluates to false
         message: Option<String>,
-        /// Timeout for the evaluation of the policy
+        /// Timeout for the evaluation of the policy. Overrides the server-wide
+        /// `policy_evaluation_limit_seconds` for this policy. Only takes effect
+        /// when timeout protection is enabled (i.e. `--disable-timeout-protection`
+        /// is not set); it is ignored otherwise.
         timeout_eval_seconds: Option<u64>,
         /// The list of host capabilities granted to this policy
         #[serde(default)]
@@ -399,6 +405,26 @@ impl PolicyOrPolicyGroup {
             }),
         }
     }
+}
+
+/// Returns `true` when at least one policy, or policy-group member, defines
+/// `timeoutEvalSeconds`.
+///
+/// `timeoutEvalSeconds` only takes effect as an override of the server-wide
+/// `policy_evaluation_limit_seconds`; when the global timeout protection is
+/// disabled (e.g. `--disable-timeout-protection`), per-policy timeouts are
+/// ignored. This helper is used to warn the operator when that combination
+/// is detected at startup.
+pub(crate) fn any_policy_has_timeout(policies: &HashMap<String, PolicyOrPolicyGroup>) -> bool {
+    policies.values().any(|policy| match policy {
+        PolicyOrPolicyGroup::Policy {
+            timeout_eval_seconds,
+            ..
+        } => timeout_eval_seconds.is_some(),
+        PolicyOrPolicyGroup::PolicyGroup { policies, .. } => policies
+            .values()
+            .any(|member| member.timeout_eval_seconds.is_some()),
+    })
 }
 
 /// Reads the policies configuration file, returns a HashMap with String as value
@@ -698,5 +724,62 @@ group_policy:
 
         let validation_result = validate_policies(&policies);
         assert_eq!(is_valid, validation_result.is_ok());
+    }
+
+    #[test]
+    fn any_policy_has_timeout_empty() {
+        let policies: HashMap<String, PolicyOrPolicyGroup> = HashMap::new();
+        assert!(!any_policy_has_timeout(&policies));
+    }
+
+    #[rstest]
+    #[case::no_timeouts(
+        r#"
+---
+example:
+  module: file:///tmp/namespace-validate-policy.wasm
+  settings: {}
+group_policy:
+  expression: "true"
+  message: "group policy message"
+  policies:
+    policy1:
+      module: file:///tmp/namespace-validate-policy.wasm
+      settings: {}
+"#,
+        false
+    )]
+    #[case::policy_with_timeout(
+        r#"
+---
+example:
+  module: file:///tmp/namespace-validate-policy.wasm
+  settings: {}
+  timeoutEvalSeconds: 5
+"#,
+        true
+    )]
+    #[case::group_member_with_timeout(
+        r#"
+---
+group_policy:
+  expression: "true"
+  message: "group policy message"
+  policies:
+    policy1:
+      module: file:///tmp/namespace-validate-policy.wasm
+      settings: {}
+    policy2:
+      module: file:///tmp/namespace-validate-policy.wasm
+      settings: {}
+      timeoutEvalSeconds: 3
+"#,
+        true
+    )]
+    fn any_policy_has_timeout_detection(#[case] policies_yaml: &str, #[case] expected: bool) {
+        let policies: HashMap<String, PolicyOrPolicyGroup> =
+            serde_yaml::from_str(policies_yaml).unwrap();
+
+        assert_eq!(expected, any_policy_has_timeout(&policies));
     }
 }

--- a/crates/policy-server/src/evaluation/evaluation_environment.rs
+++ b/crates/policy-server/src/evaluation/evaluation_environment.rs
@@ -36,6 +36,21 @@ use crate::{
 /// The digest of a WebAssembly module
 type ModuleDigest = String;
 
+/// Resolve the epoch deadline (in ticks) to use for a policy evaluation.
+///
+/// A policy's own `timeout_eval_seconds` only takes effect as an override of
+/// the server-wide `global_policy_evaluation_limit_seconds`: when the global
+/// timeout protection is disabled (`global_policy_evaluation_limit_seconds`
+/// is `None`), Wasmtime epoch interruption is not enabled on the shared
+/// engine at all, so `timeoutEvalSeconds` is ignored and no deadline is set
+/// (a startup warning is emitted for this case, see `lib.rs`).
+fn epoch_deadline_for(
+    timeout_eval_seconds: Option<u64>,
+    global_policy_evaluation_limit_seconds: Option<u64>,
+) -> Option<u64> {
+    global_policy_evaluation_limit_seconds.map(|global| timeout_eval_seconds.unwrap_or(global))
+}
+
 /// This structure contains all the policies defined by the user inside of the `policies.yml`.
 /// It also provides helper methods to perform the validation of a request and the validation
 /// of the settings provided by the user.
@@ -223,8 +238,10 @@ impl<'engine, 'precompiled_policies> EvaluationEnvironmentBuilder<'engine, 'prec
                         timeout_eval_seconds: timeout_eval_seconds.to_owned(),
                     };
 
-                    let epoch_deadline =
-                        timeout_eval_seconds.or(self.global_policy_evaluation_limit_seconds);
+                    let epoch_deadline = epoch_deadline_for(
+                        timeout_eval_seconds.to_owned(),
+                        self.global_policy_evaluation_limit_seconds,
+                    );
 
                     let host_capabilities =
                         HostCapabilities::new(host_capabilities).map_err(|e| {
@@ -299,9 +316,10 @@ impl<'engine, 'precompiled_policies> EvaluationEnvironmentBuilder<'engine, 'prec
                             timeout_eval_seconds: policy.timeout_eval_seconds,
                         };
 
-                        let epoch_deadline = policy
-                            .timeout_eval_seconds
-                            .or(self.global_policy_evaluation_limit_seconds);
+                        let epoch_deadline = epoch_deadline_for(
+                            policy.timeout_eval_seconds,
+                            self.global_policy_evaluation_limit_seconds,
+                        );
 
                         let host_capabilities = HostCapabilities::new(
                             policy.host_capabilities.clone(),
@@ -403,7 +421,6 @@ impl EvaluationEnvironment {
     ///
     /// Invariants that are not in params:
     /// - `module_digest`: obtained from `precompiled_policy.digest`
-    /// - `evaluation_limit_seconds`: obtained from `eval_ctx.epoch_deadline`
     fn register(
         &mut self,
         engine: &wasmtime::Engine,
@@ -421,12 +438,8 @@ impl EvaluationEnvironment {
             debug!(?policy_id, "create wasmtime::Module");
             let module = create_wasmtime_module(policy_id, engine, precompiled_policy)?;
             debug!(?policy_id, "create PolicyEvaluatorPre");
-            let pol_eval_pre = create_policy_evaluator_pre(
-                engine,
-                &module,
-                precompiled_policy.execution_mode,
-                eval_ctx.epoch_deadline,
-            )?;
+            let pol_eval_pre =
+                create_policy_evaluator_pre(engine, &module, precompiled_policy.execution_mode)?;
 
             self.module_digest_to_policy_evaluator_pre
                 .insert(module_digest.to_owned(), Arc::new(pol_eval_pre));
@@ -553,9 +566,10 @@ impl EvaluationEnvironment {
 
         let policy_settings = self.get_policy_settings(policy_id)?;
 
-        let epoch_deadline = policy_settings
-            .timeout_eval_seconds
-            .or(self.global_policy_evaluation_limit_seconds);
+        let epoch_deadline = epoch_deadline_for(
+            policy_settings.timeout_eval_seconds,
+            self.global_policy_evaluation_limit_seconds,
+        );
 
         let policy_evaluator_pre = self
             .module_digest_to_policy_evaluator_pre
@@ -685,9 +699,10 @@ impl EvaluationEnvironment {
                 _ => unreachable!(),
             };
 
-            let epoch_deadline = policy_settings
-                .timeout_eval_seconds
-                .or(self.global_policy_evaluation_limit_seconds);
+            let epoch_deadline = epoch_deadline_for(
+                policy_settings.timeout_eval_seconds,
+                self.global_policy_evaluation_limit_seconds,
+            );
 
             let policy_group_member_settings = PolicyGroupMemberSettings {
                 settings,
@@ -724,22 +739,25 @@ fn create_wasmtime_module(
         })
 }
 
-/// Internal function, takes care of creating the `PolicyEvaluator` instance for the given policy
+/// Internal function, takes care of creating the `PolicyEvaluator` instance for the given policy.
+///
+/// Note: this does not configure Wasmtime epoch interruption. An `engine` is
+/// always supplied by the caller (see `PolicyServer::new_from_config`), and
+/// `PolicyEvaluatorBuilder::build_engine` only applies epoch-interruption
+/// settings when it builds its own engine, so calling
+/// `enable_epoch_interruptions` here would have no effect. The engine's
+/// epoch-interruption setting is decided once in `lib.rs`; the per-evaluation
+/// deadline is applied later, via `EvaluationContext::epoch_deadline`
+/// (see `epoch_deadline_for`).
 fn create_policy_evaluator_pre(
     engine: &wasmtime::Engine,
     module: &wasmtime::Module,
     mode: PolicyExecutionMode,
-    policy_evaluation_limit_seconds: Option<u64>,
 ) -> Result<PolicyEvaluatorPre> {
-    let mut policy_evaluator_builder = PolicyEvaluatorBuilder::new()
+    let policy_evaluator_builder = PolicyEvaluatorBuilder::new()
         .engine(engine.to_owned())
         .policy_module(module.to_owned())
         .execution_mode(mode);
-
-    if let Some(limit) = policy_evaluation_limit_seconds {
-        policy_evaluator_builder =
-            policy_evaluator_builder.enable_epoch_interruptions(limit, limit);
-    }
 
     policy_evaluator_builder.build_pre().map_err(|e| {
         EvaluationError::WebAssemblyError(format!("cannot build PolicyEvaluatorPre {e}"))

--- a/crates/policy-server/src/lib.rs
+++ b/crates/policy-server/src/lib.rs
@@ -153,17 +153,13 @@ impl PolicyServer {
         // required by policies built by the official go compiler >= 1.26.0
         wasmtime_config.wasm_function_references(true);
 
-        let any_policy_has_timeout = config.policies.values().any(|policy| match policy {
-            config::PolicyOrPolicyGroup::Policy {
-                timeout_eval_seconds,
-                ..
-            } => timeout_eval_seconds.is_some(),
-            config::PolicyOrPolicyGroup::PolicyGroup { policies, .. } => policies
-                .values()
-                .any(|member| member.timeout_eval_seconds.is_some()),
-        });
-        if config.policy_evaluation_limit_seconds.is_some() || any_policy_has_timeout {
+        if config.policy_evaluation_limit_seconds.is_some() {
             wasmtime_config.epoch_interruption(true);
+        } else if config::any_policy_has_timeout(&config.policies) {
+            warn!(
+                "timeout protection is disabled: the timeoutEvalSeconds setting of policies \
+                 will be ignored"
+            );
         }
 
         let engine = wasmtime::Engine::new(&wasmtime_config)?;

--- a/crates/policy-server/tests/integration_test.rs
+++ b/crates/policy-server/tests/integration_test.rs
@@ -518,6 +518,87 @@ async fn test_timeout_protection_policy_specific_reject() {
     );
 }
 
+/// Regression test: `--disable-timeout-protection` (global
+/// `policy_evaluation_limit_seconds = None`) must be an absolute kill
+/// switch. A policy's own `timeoutEvalSeconds` only takes effect as an
+/// override of the global limit; when the global limit is disabled, epoch
+/// interruption is never enabled on the shared engine, so `timeoutEvalSeconds`
+/// must be ignored. This asserts that a policy configured with a 1s timeout,
+/// whose execution takes 4s, is *not* interrupted when the global timeout
+/// protection is disabled.
+#[tokio::test]
+async fn test_timeout_protection_disabled_ignores_policy_specific_timeout() {
+    setup();
+
+    let mut config = default_test_config();
+    config.policy_evaluation_limit_seconds = None; // global timeout protection disabled
+
+    let app = app(config).await;
+
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .header(header::CONTENT_TYPE, "application/json")
+        // This policy has a 1s timeoutEvalSeconds, and its execution time is 4s via the pod
+        // annotation. With timeout protection disabled, this must be ignored.
+        .uri("/validate/sleep-1s-timeout")
+        .body(Body::from(include_str!("data/pod_sleep_4s.json")))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let admission_review_response: AdmissionReviewResponse =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+
+    assert!(
+        admission_review_response.response.allowed,
+        "expected allowed (timeoutEvalSeconds must be ignored when timeout protection is \
+         disabled), got: {:?}",
+        admission_review_response.response
+    );
+}
+
+/// Regression test: with `--disable-timeout-protection` set, Wasmtime epoch
+/// interruption must never be enabled on the shared engine, even when a
+/// sibling policy defines `timeoutEvalSeconds`. Enabling interruption without
+/// giving every policy a deadline makes Wasmtime trap policies with no
+/// deadline of their own immediately (an interruption-enabled Store requires
+/// a deadline before executing any code). This asserts that a policy with no
+/// timeout of its own still evaluates normally in this configuration.
+#[tokio::test]
+async fn test_timeout_protection_disabled_policy_without_timeout_works() {
+    setup();
+
+    let mut config = default_test_config();
+    config.policy_evaluation_limit_seconds = None; // global timeout protection disabled
+    // `sleep-1s-timeout` (also present in this config) has `timeoutEvalSeconds`
+    // set; this must not cause epoch interruption to be enabled.
+
+    let app = app(config).await;
+
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .header(header::CONTENT_TYPE, "application/json")
+        // `sleep` has no timeoutEvalSeconds of its own.
+        .uri("/validate/sleep")
+        .body(Body::from(include_str!("data/pod_sleep_100ms.json")))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let admission_review_response: AdmissionReviewResponse =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+
+    assert!(
+        admission_review_response.response.allowed,
+        "expected allowed, got: {:?}",
+        admission_review_response.response
+    );
+}
+
 #[tokio::test]
 async fn test_context_aware_policy_host_capability_denied() {
     use std::collections::BTreeSet;


### PR DESCRIPTION
Defining timeoutEvalSeconds on a policy used to enable Wasmtime epoch interruption even when timeout protection was disabled. This was broken in two ways: the epoch ticker only ran when the global limit was set, so those per-policy timeouts never fired. Policies without their own timeout got no epoch deadline, making Wasmtime trap their evaluations immediately.

Make `--disable-timeout-protection` an absolute kill switch instead: epoch interruption is only enabled when the global timeout protection is active, and `timeoutEvalSeconds` acts purely as a per-policy override of the global limit. When the protection is disabled, per-policy timeouts are ignored and a startup warning is emitted.
