### PR TITLE
chore(deps): bump clap-documentation to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "clap-documentation"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ad77e5750448aa9e3ea12d6464716994f4aa7207a6b3aa8a4b152580236023"
+checksum = "7fc705096d9c0fd6a3849c9b92964bb828d30b3fab794a93bec123b22cac727f"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ anyhow = "1.0"
 base64 = "0.23"
 clap   = { version = "4.5", features = ["cargo", "env"] }
 # Customized crate that generate CLI reference documentation in Asciidoc format
-clap-documentation = "0.1.0"
+clap-documentation = "0.1.2"
 futures = "0.3"
 hex = "0.4"
 itertools = "0.15.0"

--- a/crates/kwctl/cli-docs.adoc
+++ b/crates/kwctl/cli-docs.adoc
@@ -85,10 +85,10 @@ Add Kubewarden metadata to a WebAssembly module
 Benchmarks a Kubewarden policy.
 
 The policy can be specified in the following ways:
-- URI: e.g., `registry://ghcr.io/kubewarden/policies/psp-policy:latest` or `https://example.com/kubewarden/policies/main/psp-policy/psp-policy.wasm`
+- URI: e.g., `registry://ghcr.io/kubewarden/policies/psp-policy:latest` or `\https://example.com/kubewarden/policies/main/psp-policy/psp-policy.wasm`
 - SHA prefix: e.g., `c3b80a10f9c3` (requires the policy to be already pulled)
-- Local WASM file: e.g., `file://home/tux/new-policy/psp-policy.wasm`
-- Local YAML file: e.g., `file://home/tux/cluster-admission-policy.yaml` (contains declarations of Kubewarden Custom Resources like `ClusterAdmissionPolicy`, `AdmissionPolicy`, etc.)
+- Local WASM file: e.g., `\file://home/tux/new-policy/psp-policy.wasm`
+- Local YAML file: e.g., `\file://home/tux/cluster-admission-policy.yaml` (contains declarations of Kubewarden Custom Resources like `ClusterAdmissionPolicy`, `AdmissionPolicy`, etc.)
 
 Default Behavior:
 If the schema is omitted, `file://` is assumed, rooted in the current directory.
@@ -345,10 +345,10 @@ Removes a Kubewarden policy from the store
 Run one or more Kubewarden policies locally.
 
 The policy can be specified in the following ways:
-- URI: e.g., `registry://ghcr.io/kubewarden/policies/psp-policy:latest` or `https://example.com/kubewarden/policies/main/psp-policy/psp-policy.wasm`
+- URI: e.g., `registry://ghcr.io/kubewarden/policies/psp-policy:latest` or `\https://example.com/kubewarden/policies/main/psp-policy/psp-policy.wasm`
 - SHA prefix: e.g., `c3b80a10f9c3` (requires the policy to be already pulled)
-- Local WASM file: e.g., `file://home/tux/new-policy/psp-policy.wasm`
-- Local YAML file: e.g., `file://home/tux/cluster-admission-policy.yaml` (contains declarations of Kubewarden Custom Resources like `ClusterAdmissionPolicy`, `AdmissionPolicy`, etc.)
+- Local WASM file: e.g., `\file://home/tux/new-policy/psp-policy.wasm`
+- Local YAML file: e.g., `\file://home/tux/cluster-admission-policy.yaml` (contains declarations of Kubewarden Custom Resources like `ClusterAdmissionPolicy`, `AdmissionPolicy`, etc.)
 
 Default Behavior:
 If the schema is omitted, `file://` is assumed, rooted in the current directory.


### PR DESCRIPTION
## Description

Version 0.1.2 escapes URI schemes inside monospace text in the generated AsciiDoc. The documentation site no longer needs a manual patch on the copied file.

This is done to avoid the regressions detected [here](https://github.com/kubewarden/docs/pull/872#pullrequestreview-5007220688)