### PR TITLE
docs: add AGENTS.md guidance for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ one has precedence for the files in its subtree:
 
 ## Project overview
 
-Kubewarden is a CNCF dynamic admission controller for Kubernetes. It evaluates
-policies that are compiled to WebAssembly. This repository is a monorepo. It
-contains these components:
+- Kubewarden is a CNCF dynamic admission controller for Kubernetes.
+- It evaluates policies that are compiled to WebAssembly.
+- This repository is a monorepo. It contains these components:
 
 - `controller` — Go — `cmd/controller`, `internal/controller`
 - `audit-scanner` — Go — `cmd/audit-scanner`, `internal/audit-scanner`
@@ -22,21 +22,19 @@ contains these components:
 
 ## Structure
 
-```
-api/policies/v1/         CRD types (storage version) and admission webhooks
-api/policies/v1alpha2/   deprecated CRD types — new fields go in v1
-cmd/                     entrypoints of the controller and the audit scanner
-internal/controller/     reconcilers and the envtest integration suite
-internal/audit-scanner/  the audit scanner
-internal/certs/          generation of the CA and the serving certificates
-crates/                  Rust workspace (policy-server, kwctl, policy-evaluator,
-                         policy-fetcher, burrego, context-aware-test-policy)
-charts/admission-controller/  the single unified Helm chart
-e2e/                     Go end-to-end tests that run against a kind cluster
-docs/                    generated and hand-written documentation
-hack/                    helpers for code generation and CI checks
-scripts/                 shell utilities that shellcheck examines
-```
+- `api/policies/v1/` — CRD types (storage version) and admission webhooks
+- `api/policies/v1alpha2/` — deprecated CRD types. New fields go in v1.
+- `cmd/` — entrypoints of the controller and the audit scanner
+- `internal/controller/` — reconcilers and the envtest integration suite
+- `internal/audit-scanner/` — the audit scanner
+- `internal/certs/` — generation of the CA and the serving certificates
+- `crates/` — Rust workspace (policy-server, kwctl, policy-evaluator,
+  policy-fetcher, burrego, context-aware-test-policy)
+- `charts/admission-controller/` — the single unified Helm chart
+- `e2e/` — Go end-to-end tests that run against a kind cluster
+- `docs/` — generated and hand-written documentation
+- `hack/` — helpers for code generation and CI checks
+- `scripts/` — shell utilities that shellcheck examines
 
 - The API server sends the admission requests to the policy server. The policy
   server evaluates the policies and answers with a decision.
@@ -100,14 +98,14 @@ can find the defect.
 
 ## Generated code — the primary rule
 
-Never edit a generated file by hand. If you change a file in `api/policies/`, a
-`+kubebuilder:` marker, or `charts/admission-controller/values.yaml`, run these
-commands:
+Never edit a generated file by hand.
 
-```sh
-make generate
-make check-generate
-```
+Run `make generate`, then run `make check-generate`, after a change to one of
+these:
+
+- A file in `api/policies/`
+- A `+kubebuilder:` marker
+- `charts/admission-controller/values.yaml`
 
 Two conditions need your attention:
 
@@ -122,17 +120,17 @@ Two conditions need your attention:
 
 ## Commits
 
-Write commit messages in the Conventional Commits format: `type(scope):
-subject`. For example: `feat(resolver): add a new solver strategy`. The usual
-types are `feat`, `fix`, `perf`, `refactor`, `chore`, `ci` and `docs`.
+- Write the commit message in the Conventional Commits format:
+  `type(scope): subject`. For example: `feat(resolver): add a new solver
+  strategy`.
+- The usual types are `feat`, `fix`, `perf`, `refactor`, `chore`, `ci` and
+  `docs`.
+- Each commit needs a DCO sign-off. Use `git commit -s`.
+- Each commit that an AI helped to write needs an `Assisted-by:` trailer.
 
-Each commit needs a DCO sign-off. Use `git commit -s`.
+Example commit message:
 
-Each commit that an AI helped to write needs an `Assisted-by:` trailer.
-
-```
-feat(controller): reconcile policy server PDBs
-
-Signed-off-by: Jane Doe <jane@example.com>
-Assisted-by: Claude Opus 4.5
-```
+> feat(controller): reconcile policy server PDBs
+>
+> Signed-off-by: Jane Doe <jane@example.com>
+> Assisted-by: Claude Opus 4.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,19 @@ hack/                    helpers for code generation and CI checks
 scripts/                 shell utilities that shellcheck examines
 ```
 
+- The API server sends the admission requests to the policy server. The policy
+  server evaluates the policies and answers with a decision.
+- The controller watches the policy resources and writes the configuration of
+  the policy server. A change of that configuration starts a new rollout of the
+  policy server. The policy server does not read the configuration again while
+  it runs.
+- The audit scanner sends the resources that are already in the cluster to the
+  policy server. It writes the results into the report resources.
+- The controller manages the certificates. It creates and rotates the CA and the
+  serving certificate of each policy server, and it keeps the CA current in the
+  webhook configurations.
+- `kwctl` is not in the path of the data. It is a local CLI.
+
 ## Commands
 
 Run these commands from the root of the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,11 @@ Kubewarden is a CNCF dynamic admission controller for Kubernetes. It evaluates
 policies that are compiled to WebAssembly. This repository is a monorepo. It
 contains these components:
 
-| Component        | Language | Path                                          |
-| ---------------- | -------- | --------------------------------------------- |
-| `controller`     | Go       | `cmd/controller`, `internal/controller`       |
-| `audit-scanner`  | Go       | `cmd/audit-scanner`, `internal/audit-scanner` |
-| `policy-server`  | Rust     | `crates/policy-server`                        |
-| `kwctl`          | Rust     | `crates/kwctl`                                |
-| Helm chart       | YAML     | `charts/admission-controller`                 |
+- `controller` — Go — `cmd/controller`, `internal/controller`
+- `audit-scanner` — Go — `cmd/audit-scanner`, `internal/audit-scanner`
+- `policy-server` — Rust — `crates/policy-server`
+- `kwctl` — Rust — `crates/kwctl`
+- Helm chart — YAML — `charts/admission-controller`
 
 ## Structure
 
@@ -44,41 +42,37 @@ scripts/                 shell utilities that shellcheck examines
 
 Run these commands from the root of the repository.
 
-| Command                  | Purpose                                                             |
-| ------------------------ | ------------------------------------------------------------------- |
-| `make all`               | Build the controller, the audit scanner, policy-server and kwctl     |
-| `make controller`        | `go build -o ./bin/controller ./cmd/controller`                      |
-| `make audit-scanner`     | `go build -o ./bin/audit-scanner ./cmd/audit-scanner`                |
-| `make policy-server`     | `cross build --release -p policy-server`. It needs `cross`.          |
-| `make kwctl`             | `cross build --release -p kwctl`. It needs `cross`.                  |
-| `make test`              | `test-go` and then `test-rust`                                       |
-| `make test-go`           | `go vet`, then all Go tests except `e2e/`, with envtest and `-race`  |
-| `make test-rust`         | Delegate to `crates/Makefile`                                        |
-| `make helm-unittest`     | Run the unit tests of the Helm chart                                 |
-| `make test-e2e`          | Build the three images, then run `go test ./e2e/ -v`                 |
-| `make test-all`          | `test`, `helm-unittest` and `test-e2e`                               |
-| `make fmt-go`            | `go fmt ./...`                                                       |
-| `make lint-go`           | Run golangci-lint v2.13.1. The Makefile downloads it into `bin/`.    |
-| `make lint-go-fix`       | Run golangci-lint with `--fix`                                       |
-| `make lint`              | `lint-go` and `lint-rust`                                            |
-| `make generate`          | Generate all the generated files again. Read the section that follows. |
-| `make manifests`         | Generate the CRDs, the RBAC rules and the webhook manifests again    |
-| `make check-generate`    | `check-questions`, `generate`, then fail if the tree is dirty        |
-| `make typos`             | Examine the spelling with `typos-cli`                                |
-| `make zizmor`            | Do a static analysis of the GitHub Actions workflows                 |
-| `make advisories-rust`   | `cargo deny check advisories`                                        |
+- `make all` — Build the controller, the audit scanner, policy-server and kwctl
+- `make controller` — `go build -o ./bin/controller ./cmd/controller`
+- `make audit-scanner` — `go build -o ./bin/audit-scanner ./cmd/audit-scanner`
+- `make policy-server` — `cross build --release -p policy-server`. It needs `cross`.
+- `make kwctl` — `cross build --release -p kwctl`. It needs `cross`.
+- `make test` — `test-go` and then `test-rust`
+- `make test-go` — `go vet`, then all Go tests except `e2e/`, with envtest and `-race`
+- `make test-rust` — Delegate to `crates/Makefile`
+- `make helm-unittest` — Run the unit tests of the Helm chart
+- `make test-e2e` — Build the three images, then run `go test ./e2e/ -v`
+- `make test-all` — `test`, `helm-unittest` and `test-e2e`
+- `make fmt-go` — `go fmt ./...`
+- `make lint-go` — Run golangci-lint v2.13.1. The Makefile downloads it into `bin/`.
+- `make lint-go-fix` — Run golangci-lint with `--fix`
+- `make lint` — `lint-go` and `lint-rust`
+- `make generate` — Generate all the generated files again. Read the section that follows.
+- `make manifests` — Generate the CRDs, the RBAC rules and the webhook manifests again
+- `make check-generate` — `check-questions`, `generate`, then fail if the tree is dirty
+- `make typos` — Examine the spelling with `typos-cli`
+- `make zizmor` — Do a static analysis of the GitHub Actions workflows
+- `make advisories-rust` — `cargo deny check advisories`
 
 ## Testing strategy
 
 The project has four levels of tests. Write the test at the lowest level that
 can find the defect.
 
-| Level                  | Location                             | Command             | When to write one                                          |
-| ---------------------- | ------------------------------------ | ------------------- | ---------------------------------------------------------- |
-| Go unit                | beside the code that it tests        | `make test-go`      | The default. Use it for logic that needs no API server.     |
-| Controller integration | `internal/controller/`               | `make test-go`      | The behavior of a reconciler against a real API server.     |
-| Helm chart unit        | `charts/admission-controller/tests/` | `make helm-unittest` | Any change of a template or of a value.                    |
-| Go end to end          | `e2e/`                               | `make test-e2e`     | Only the behavior of the full installation.                 |
+- Go unit — beside the code that it tests — `make test-go` — The default. Use it for logic that needs no API server.
+- Controller integration — `internal/controller/` — `make test-go` — The behavior of a reconciler against a real API server.
+- Helm chart unit — `charts/admission-controller/tests/` — `make helm-unittest` — Any change of a template or of a value.
+- Go end to end — `e2e/` — `make test-e2e` — Only the behavior of the full installation.
 
 ## Development principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,10 @@
 # AGENTS.md
 
-This file gives directions to AI coding agents that work in the Kubewarden
-`adm-controller` monorepo. Other `AGENTS.md` files exist in subdirectories. Each
-one has precedence for the files in its subtree:
-
-- [`crates/AGENTS.md`](crates/AGENTS.md) — the Rust workspace
-- [`charts/admission-controller/AGENTS.md`](charts/admission-controller/AGENTS.md) — the Helm chart
-- [`internal/controller/AGENTS.md`](internal/controller/AGENTS.md) — the controller and its envtest suite
-
 ## Project overview
 
 - Kubewarden is a CNCF dynamic admission controller for Kubernetes.
 - It evaluates policies that are compiled to WebAssembly.
 - This repository is a monorepo. It contains these components:
-
 - `controller` — Go — `cmd/controller`, `internal/controller`
 - `audit-scanner` — Go — `cmd/audit-scanner`, `internal/audit-scanner`
 - `policy-server` — Rust — `crates/policy-server`
@@ -35,7 +26,6 @@ one has precedence for the files in its subtree:
 - `docs/` — generated and hand-written documentation
 - `hack/` — helpers for code generation and CI checks
 - `scripts/` — shell utilities that shellcheck examines
-
 - The API server sends the admission requests to the policy server. The policy
   server evaluates the policies and answers with a decision.
 - The controller watches the policy resources and writes the configuration of
@@ -77,9 +67,7 @@ Run these commands from the root of the repository.
 
 ## Testing strategy
 
-The project has four levels of tests. Write the test at the lowest level that
-can find the defect.
-
+- The project has four levels of tests. Write the test at the lowest level that can find the defect.
 - Go unit — beside the code that it tests — `make test-go` — The default. Use it for logic that needs no API server.
 - Controller integration — `internal/controller/` — `make test-go` — The behavior of a reconciler against a real API server.
 - Helm chart unit — `charts/admission-controller/tests/` — `make helm-unittest` — Any change of a template or of a value.
@@ -98,14 +86,12 @@ can find the defect.
 
 ## Generated code — the primary rule
 
-Never edit a generated file by hand.
-
-Run `make generate`, then run `make check-generate`, after a change to one of
+- Never edit a generated file by hand.
+- Run `make generate`, then run `make check-generate`, after a change to one of
 these:
-
-- A file in `api/policies/`
-- A `+kubebuilder:` marker
-- `charts/admission-controller/values.yaml`
+  - A file in `api/policies/`
+  - A `+kubebuilder:` marker
+  - `charts/admission-controller/values.yaml`
 
 Two conditions need your attention:
 
@@ -130,7 +116,9 @@ Two conditions need your attention:
 
 Example commit message:
 
-> feat(controller): reconcile policy server PDBs
->
-> Signed-off-by: Jane Doe <jane@example.com>
-> Assisted-by: Claude Opus 4.5
+```
+feat(controller): reconcile policy server PDBs
+
+Signed-off-by: Jane Doe <jane@example.com>
+Assisted-by: Claude Opus 4.5
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# AGENTS.md
+
+This file gives directions to AI coding agents that work in the Kubewarden
+`adm-controller` monorepo. Other `AGENTS.md` files exist in subdirectories. Each
+one has precedence for the files in its subtree:
+
+- [`crates/AGENTS.md`](crates/AGENTS.md) — the Rust workspace
+- [`charts/admission-controller/AGENTS.md`](charts/admission-controller/AGENTS.md) — the Helm chart
+- [`internal/controller/AGENTS.md`](internal/controller/AGENTS.md) — the controller and its envtest suite
+
+## Project overview
+
+Kubewarden is a CNCF dynamic admission controller for Kubernetes. It evaluates
+policies that are compiled to WebAssembly. This repository is a monorepo. It
+contains these components:
+
+| Component        | Language | Path                                          |
+| ---------------- | -------- | --------------------------------------------- |
+| `controller`     | Go       | `cmd/controller`, `internal/controller`       |
+| `audit-scanner`  | Go       | `cmd/audit-scanner`, `internal/audit-scanner` |
+| `policy-server`  | Rust     | `crates/policy-server`                        |
+| `kwctl`          | Rust     | `crates/kwctl`                                |
+| Helm chart       | YAML     | `charts/admission-controller`                 |
+
+## Structure
+
+```
+api/policies/v1/         CRD types (storage version) and admission webhooks
+api/policies/v1alpha2/   deprecated CRD types — new fields go in v1
+cmd/                     entrypoints of the controller and the audit scanner
+internal/controller/     reconcilers and the envtest integration suite
+internal/audit-scanner/  the audit scanner
+internal/certs/          generation of the CA and the serving certificates
+crates/                  Rust workspace (policy-server, kwctl, policy-evaluator,
+                         policy-fetcher, burrego, context-aware-test-policy)
+charts/admission-controller/  the single unified Helm chart
+e2e/                     Go end-to-end tests that run against a kind cluster
+docs/                    generated and hand-written documentation
+hack/                    helpers for code generation and CI checks
+scripts/                 shell utilities that shellcheck examines
+```
+
+## Commands
+
+Run these commands from the root of the repository.
+
+| Command                  | Purpose                                                             |
+| ------------------------ | ------------------------------------------------------------------- |
+| `make all`               | Build the controller, the audit scanner, policy-server and kwctl     |
+| `make controller`        | `go build -o ./bin/controller ./cmd/controller`                      |
+| `make audit-scanner`     | `go build -o ./bin/audit-scanner ./cmd/audit-scanner`                |
+| `make policy-server`     | `cross build --release -p policy-server`. It needs `cross`.          |
+| `make kwctl`             | `cross build --release -p kwctl`. It needs `cross`.                  |
+| `make test`              | `test-go` and then `test-rust`                                       |
+| `make test-go`           | `go vet`, then all Go tests except `e2e/`, with envtest and `-race`  |
+| `make test-rust`         | Delegate to `crates/Makefile`                                        |
+| `make helm-unittest`     | Run the unit tests of the Helm chart                                 |
+| `make test-e2e`          | Build the three images, then run `go test ./e2e/ -v`                 |
+| `make test-all`          | `test`, `helm-unittest` and `test-e2e`                               |
+| `make fmt-go`            | `go fmt ./...`                                                       |
+| `make lint-go`           | Run golangci-lint v2.13.1. The Makefile downloads it into `bin/`.    |
+| `make lint-go-fix`       | Run golangci-lint with `--fix`                                       |
+| `make lint`              | `lint-go` and `lint-rust`                                            |
+| `make generate`          | Generate all the generated files again. Read the section that follows. |
+| `make manifests`         | Generate the CRDs, the RBAC rules and the webhook manifests again    |
+| `make check-generate`    | `check-questions`, `generate`, then fail if the tree is dirty        |
+| `make typos`             | Examine the spelling with `typos-cli`                                |
+| `make zizmor`            | Do a static analysis of the GitHub Actions workflows                 |
+| `make advisories-rust`   | `cargo deny check advisories`                                        |
+
+## Testing strategy
+
+The project has four levels of tests. Write the test at the lowest level that
+can find the defect.
+
+| Level                  | Location                             | Command             | When to write one                                          |
+| ---------------------- | ------------------------------------ | ------------------- | ---------------------------------------------------------- |
+| Go unit                | beside the code that it tests        | `make test-go`      | The default. Use it for logic that needs no API server.     |
+| Controller integration | `internal/controller/`               | `make test-go`      | The behavior of a reconciler against a real API server.     |
+| Helm chart unit        | `charts/admission-controller/tests/` | `make helm-unittest` | Any change of a template or of a value.                    |
+| Go end to end          | `e2e/`                               | `make test-e2e`     | Only the behavior of the full installation.                 |
+
+## Development principles
+
+- Generated files come from their markers. Change the marker, then generate the
+  file again.
+- Test your change. Run the lint and the tests of the component that you
+  touched.
+- Code has a place. The CRD types go in `api/policies/v1`. The reconcilers go in
+  `internal/controller`. The evaluation of the policies stays in `crates/`. The
+  chart holds only the packaging.
+- Prefer the narrow RBAC rule and the explicit failure to the convenient default.
+
+## Generated code — the primary rule
+
+Never edit a generated file by hand. If you change a file in `api/policies/`, a
+`+kubebuilder:` marker, or `charts/admission-controller/values.yaml`, run these
+commands:
+
+```sh
+make generate
+make check-generate
+```
+
+Two conditions need your attention:
+
+- `make manifests` writes the CRDs and the RBAC rules directly into the Helm
+  chart. It does not write them into a `config/` directory. The webhook output
+  goes to `charts/generated-webhooks-manifests.yaml`. You must merge that file
+  by hand into
+  `charts/admission-controller/templates/controller/webhooks.yaml`.
+- The envtest suite loads the CRDs from the chart. Thus a chart that is not
+  current breaks the tests in `internal/controller`. Generate the chart again
+  before you run `make test-go`.
+
+## Commits
+
+Write commit messages in the Conventional Commits format: `type(scope):
+subject`. For example: `feat(resolver): add a new solver strategy`. The usual
+types are `feat`, `fix`, `perf`, `refactor`, `chore`, `ci` and `docs`.
+
+Each commit needs a DCO sign-off. Use `git commit -s`.
+
+Each commit that an AI helped to write needs an `Assisted-by:` trailer.
+
+```
+feat(controller): reconcile policy server PDBs
+
+Signed-off-by: Jane Doe <jane@example.com>
+Assisted-by: Claude Opus 4.5
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Kubewarden is a CNCF dynamic admission controller for Kubernetes.
 - It evaluates policies that are compiled to WebAssembly.
 - This repository is a monorepo. It contains these components:
+
 - `controller` — Go — `cmd/controller`, `internal/controller`
 - `audit-scanner` — Go — `cmd/audit-scanner`, `internal/audit-scanner`
 - `policy-server` — Rust — `crates/policy-server`
@@ -26,6 +27,7 @@
 - `docs/` — generated and hand-written documentation
 - `hack/` — helpers for code generation and CI checks
 - `scripts/` — shell utilities that shellcheck examines
+
 - The API server sends the admission requests to the policy server. The policy
   server evaluates the policies and answers with a decision.
 - The controller watches the policy resources and writes the configuration of
@@ -67,7 +69,8 @@ Run these commands from the root of the repository.
 
 ## Testing strategy
 
-- The project has four levels of tests. Write the test at the lowest level that can find the defect.
+- The project has four levels of tests. Write the test at the lowest level
+  that can find the defect.
 - Go unit — beside the code that it tests — `make test-go` — The default. Use it for logic that needs no API server.
 - Controller integration — `internal/controller/` — `make test-go` — The behavior of a reconciler against a real API server.
 - Helm chart unit — `charts/admission-controller/tests/` — `make helm-unittest` — Any change of a template or of a value.
@@ -87,8 +90,8 @@ Run these commands from the root of the repository.
 ## Generated code — the primary rule
 
 - Never edit a generated file by hand.
-- Run `make generate`, then run `make check-generate`, after a change to one of
-these:
+- Run `make generate`, then run `make check-generate`, after a change to one
+  of these:
   - A file in `api/policies/`
   - A `+kubebuilder:` marker
   - `charts/admission-controller/values.yaml`

--- a/charts/admission-controller/AGENTS.md
+++ b/charts/admission-controller/AGENTS.md
@@ -39,11 +39,9 @@ value on the manifest, not only its presence in `values.yaml`.
 
 ## Generated files — do not edit them by hand
 
-| File                                                    | Source of truth                                        |
-| ------------------------------------------------------- | ------------------------------------------------------ |
-| `templates/crds/policies.kubewarden.io_*.yaml`           | the `+kubebuilder:` markers in `api/policies/`          |
-| `templates/controller/controller-rbac-roles.yaml`        | the `+kubebuilder:rbac:` markers in `internal/controller/` |
-| `values.schema.json`                                     | `values.yaml`                                          |
+- `templates/crds/policies.kubewarden.io_*.yaml` — the `+kubebuilder:` markers in `api/policies/`
+- `templates/controller/controller-rbac-roles.yaml` — the `+kubebuilder:rbac:` markers in `internal/controller/`
+- `values.schema.json` — `values.yaml`
 
 To generate these files again, run `make manifests` and `make generate-chart`
 from the root of the repository. `make generate` runs both. Then run

--- a/charts/admission-controller/AGENTS.md
+++ b/charts/admission-controller/AGENTS.md
@@ -1,10 +1,9 @@
 # AGENTS.md — the Helm chart
 
-This file applies to all the files in `charts/admission-controller/`. The root
-[`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
-
-This is the single unified chart. It installs the controller, the audit scanner
-and the defaults of the policy server.
+- This file applies to all the files in `charts/admission-controller/`. The
+root [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+- This is the single unified chart. It installs the controller, the audit
+scanner and the defaults of the policy server.
 
 ## Structure
 
@@ -18,8 +17,7 @@ and the defaults of the policy server.
 
 ## Testing strategy
 
-Run `make helm-unittest`.
-
+- Run `make helm-unittest`.
 - A new value needs a test that renders it.
 - The test must show the effect of the value on the manifest, not only its
   presence in `values.yaml`.
@@ -38,7 +36,6 @@ Run `make helm-unittest`.
 - `templates/crds/policies.kubewarden.io_*.yaml` — the `+kubebuilder:` markers in `api/policies/`
 - `templates/controller/controller-rbac-roles.yaml` — the `+kubebuilder:rbac:` markers in `internal/controller/`
 - `values.schema.json` — `values.yaml`
-
 - To generate these files again, run `make manifests` and `make generate-chart`
   from the root of the repository.
 - `make generate` runs both. Then run `make check-generate`.

--- a/charts/admission-controller/AGENTS.md
+++ b/charts/admission-controller/AGENTS.md
@@ -8,25 +8,21 @@ and the defaults of the policy server.
 
 ## Structure
 
-```
-templates/controller/    the deployment, the service, the RBAC rules, the
-                         webhooks and the hooks of the controller and the
-                         audit scanner
-templates/crds/          the CRDs of Kubewarden and the imported report CRDs
-templates/defaults/      the default policy server and its RBAC rules
-tests/                   the unit tests of the chart
-values.yaml              the values that the user can set
-questions.yaml           the form of the Rancher user interface
-```
+- `templates/controller/` — the deployment, the service, the RBAC rules, the
+  webhooks and the hooks of the controller and the audit scanner
+- `templates/crds/` — the CRDs of Kubewarden and the imported report CRDs
+- `templates/defaults/` — the default policy server and its RBAC rules
+- `tests/` — the unit tests of the chart
+- `values.yaml` — the values that the user can set
+- `questions.yaml` — the form of the Rancher user interface
 
 ## Testing strategy
 
-```sh
-make helm-unittest
-```
+Run `make helm-unittest`.
 
-A new value needs a test that renders it. The test must show the effect of the
-value on the manifest, not only its presence in `values.yaml`.
+- A new value needs a test that renders it.
+- The test must show the effect of the value on the manifest, not only its
+  presence in `values.yaml`.
 
 ## Development principles
 
@@ -43,25 +39,26 @@ value on the manifest, not only its presence in `values.yaml`.
 - `templates/controller/controller-rbac-roles.yaml` — the `+kubebuilder:rbac:` markers in `internal/controller/`
 - `values.schema.json` — `values.yaml`
 
-To generate these files again, run `make manifests` and `make generate-chart`
-from the root of the repository. `make generate` runs both. Then run
-`make check-generate`.
-
-To change a field of a CRD or an RBAC rule, edit the marker in the Go code. Never
-edit the YAML. `make manifests` also processes `controller-rbac-roles.yaml` with
-`sed`. Thus it is safe to run the target again.
-
-The files `templates/crds/policyreports.yaml` and
-`templates/crds/clusterpolicyreports.yaml` are different. They are third-party
-CRDs inside Helm conditionals. controller-gen does not produce them.
+- To generate these files again, run `make manifests` and `make generate-chart`
+  from the root of the repository.
+- `make generate` runs both. Then run `make check-generate`.
+- To change a field of a CRD or an RBAC rule, edit the marker in the Go code.
+  Never edit the YAML.
+- `make manifests` also processes `controller-rbac-roles.yaml` with `sed`. It
+  is safe to run the target again.
+- The files `templates/crds/policyreports.yaml` and
+  `templates/crds/clusterpolicyreports.yaml` are different. They are
+  third-party CRDs inside Helm conditionals. controller-gen does not produce
+  them.
 
 ## The webhook manifests need a manual merge
 
-`make manifests` writes the webhook configuration to
-`charts/generated-webhooks-manifests.yaml`. That file is outside this directory,
-and the chart does not use it. Read it and merge the changes by hand into
-`templates/controller/webhooks.yaml`. That file is a template. Thus a command
-cannot overwrite it.
+- `make manifests` writes the webhook configuration to
+  `charts/generated-webhooks-manifests.yaml`.
+- That file is outside this directory, and the chart does not use it.
+- Read it and merge the changes by hand into
+  `templates/controller/webhooks.yaml`.
+- That file is a template. A command cannot overwrite it.
 
 ## Conditions that need your attention
 

--- a/charts/admission-controller/AGENTS.md
+++ b/charts/admission-controller/AGENTS.md
@@ -1,9 +1,9 @@
 # AGENTS.md — the Helm chart
 
 - This file applies to all the files in `charts/admission-controller/`. The
-root [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+  root [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
 - This is the single unified chart. It installs the controller, the audit
-scanner and the defaults of the policy server.
+  scanner and the defaults of the policy server.
 
 ## Structure
 
@@ -36,6 +36,7 @@ scanner and the defaults of the policy server.
 - `templates/crds/policies.kubewarden.io_*.yaml` — the `+kubebuilder:` markers in `api/policies/`
 - `templates/controller/controller-rbac-roles.yaml` — the `+kubebuilder:rbac:` markers in `internal/controller/`
 - `values.schema.json` — `values.yaml`
+
 - To generate these files again, run `make manifests` and `make generate-chart`
   from the root of the repository.
 - `make generate` runs both. Then run `make check-generate`.

--- a/charts/admission-controller/AGENTS.md
+++ b/charts/admission-controller/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md — the Helm chart
+
+This file applies to all the files in `charts/admission-controller/`. The root
+[`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+
+This is the single unified chart. It installs the controller, the audit scanner
+and the defaults of the policy server.
+
+## Structure
+
+```
+templates/controller/    the deployment, the service, the RBAC rules, the
+                         webhooks and the hooks of the controller and the
+                         audit scanner
+templates/crds/          the CRDs of Kubewarden and the imported report CRDs
+templates/defaults/      the default policy server and its RBAC rules
+tests/                   the unit tests of the chart
+values.yaml              the values that the user can set
+questions.yaml           the form of the Rancher user interface
+```
+
+## Testing strategy
+
+```sh
+make helm-unittest
+```
+
+A new value needs a test that renders it. The test must show the effect of the
+value on the manifest, not only its presence in `values.yaml`.
+
+## Development principles
+
+- `questions.yaml` follows `values.yaml`. A value that the user can set needs
+  an entry in both files.
+- Every template must render with the default values. A value with no default
+  must fail with a message that names the value.
+- The chart holds the packaging. Behavior belongs to the controller or to the
+  policy server.
+
+## Generated files — do not edit them by hand
+
+| File                                                    | Source of truth                                        |
+| ------------------------------------------------------- | ------------------------------------------------------ |
+| `templates/crds/policies.kubewarden.io_*.yaml`           | the `+kubebuilder:` markers in `api/policies/`          |
+| `templates/controller/controller-rbac-roles.yaml`        | the `+kubebuilder:rbac:` markers in `internal/controller/` |
+| `values.schema.json`                                     | `values.yaml`                                          |
+
+To generate these files again, run `make manifests` and `make generate-chart`
+from the root of the repository. `make generate` runs both. Then run
+`make check-generate`.
+
+To change a field of a CRD or an RBAC rule, edit the marker in the Go code. Never
+edit the YAML. `make manifests` also processes `controller-rbac-roles.yaml` with
+`sed`. Thus it is safe to run the target again.
+
+The files `templates/crds/policyreports.yaml` and
+`templates/crds/clusterpolicyreports.yaml` are different. They are third-party
+CRDs inside Helm conditionals. controller-gen does not produce them.
+
+## The webhook manifests need a manual merge
+
+`make manifests` writes the webhook configuration to
+`charts/generated-webhooks-manifests.yaml`. That file is outside this directory,
+and the chart does not use it. Read it and merge the changes by hand into
+`templates/controller/webhooks.yaml`. That file is a template. Thus a command
+cannot overwrite it.
+
+## Conditions that need your attention
+
+- The envtest suite in `internal/controller/` loads the CRDs directly from
+  `templates/crds/`. Thus a chart that is not current breaks the Go tests.
+  Generate the chart again before you run `make test-go`.
+- The CRDs carry the annotation `helm.sh/resource-policy: keep`. Thus
+  `helm uninstall` keeps them, and this behavior is intentional. To install again
+  with a different release name or namespace, use
+  `helm install ... --take-ownership`. This flag needs Helm 3.18 or later.
+- The file `Chart.lock` pins the subcharts in `charts/*.tgz`. To update one,
+  change `Chart.yaml` and write the lock file again. Do not edit the archives.

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -12,13 +12,14 @@ This file applies to all the files in `crates/`. The root
 - `burrego` — Evaluator for Rego (OPA and Gatekeeper)
 - `context-aware-test-policy` — A test fixture. The CI matrix does not include it.
 
-The Cargo workspace root is the `Cargo.toml` in the root of the repository. It
-declares `members = ["crates/*"]`.
+- The Cargo workspace root is the `Cargo.toml` in the root of the repository.
+  It declares `members = ["crates/*"]`.
 
 ## Commands
 
-The file `crates/Makefile` collects the operations for the full workspace. Each
-crate also has a `Makefile`. The CI calls those crate Makefiles directly.
+- The file `crates/Makefile` collects the operations for the full workspace.
+- Each crate also has a `Makefile`. The CI calls those crate Makefiles
+  directly.
 
 - `make build` (from `crates/`) — `cargo build --release`
 - `make fmt` (from `crates/`) — `cargo +nightly fmt --all -- --check`
@@ -53,10 +54,9 @@ The workspace has three levels of tests.
 - Integration — `make integration-tests` — The public interface of one crate. `cargo test --test '*'`.
 - End to end — `make e2e-tests` — The full binary, with the network and the registries.
 
-Some tests need a feature. The sigstore tests need `sigstore-testing`. The
-tracing tests of `policy-server` need `otel_tests`.
-
-Write the test in the crate that owns the behavior.
+- Some tests need a feature. The sigstore tests need `sigstore-testing`. The
+  tracing tests of `policy-server` need `otel_tests`.
+- Write the test in the crate that owns the behavior.
 
 ## Development principles
 

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -5,14 +5,12 @@ This file applies to all the files in `crates/`. The root
 
 ## Structure
 
-| Crate                       | Purpose                                                    |
-| --------------------------- | ---------------------------------------------------------- |
-| `policy-server`             | HTTP server that evaluates WebAssembly admission policies   |
-| `kwctl`                     | CLI that pulls, runs, verifies, inspects and annotates policies |
-| `policy-evaluator`          | Engine that evaluates policies (Wasm and Rego)              |
-| `policy-fetcher`            | Fetches policies from OCI and HTTPS, and verifies signatures |
-| `burrego`                   | Evaluator for Rego (OPA and Gatekeeper)                     |
-| `context-aware-test-policy` | A test fixture. The CI matrix does not include it.          |
+- `policy-server` — HTTP server that evaluates WebAssembly admission policies
+- `kwctl` — CLI that pulls, runs, verifies, inspects and annotates policies
+- `policy-evaluator` — Engine that evaluates policies (Wasm and Rego)
+- `policy-fetcher` — Fetches policies from OCI and HTTPS, and verifies signatures
+- `burrego` — Evaluator for Rego (OPA and Gatekeeper)
+- `context-aware-test-policy` — A test fixture. The CI matrix does not include it.
 
 The Cargo workspace root is the `Cargo.toml` in the root of the repository. It
 declares `members = ["crates/*"]`.
@@ -22,17 +20,15 @@ declares `members = ["crates/*"]`.
 The file `crates/Makefile` collects the operations for the full workspace. Each
 crate also has a `Makefile`. The CI calls those crate Makefiles directly.
 
-| Command (from `crates/`)   | Effect                                                        |
-| -------------------------- | ------------------------------------------------------------- |
-| `make build`               | `cargo build --release`                                       |
-| `make fmt`                 | `cargo +nightly fmt --all -- --check`                          |
-| `make lint`                | `cargo clippy --workspace -- -D warnings`                      |
-| `make lint-fix`            | `cargo clippy --workspace --fix --allow-dirty --allow-staged`  |
-| `make check`               | `cargo check --workspace`                                      |
-| `make test`                | The `test` target of each crate. Each one first runs fmt and lint. |
-| `make unit-tests`          | `cargo test --lib` for each crate. kwctl uses `--bins`.        |
-| `make e2e-tests`           | The integration and e2e targets of each crate                  |
-| `make coverage`            | Coverage of the unit tests and of the integration tests        |
+- `make build` (from `crates/`) — `cargo build --release`
+- `make fmt` (from `crates/`) — `cargo +nightly fmt --all -- --check`
+- `make lint` (from `crates/`) — `cargo clippy --workspace -- -D warnings`
+- `make lint-fix` (from `crates/`) — `cargo clippy --workspace --fix --allow-dirty --allow-staged`
+- `make check` (from `crates/`) — `cargo check --workspace`
+- `make test` (from `crates/`) — The `test` target of each crate. Each one first runs fmt and lint.
+- `make unit-tests` (from `crates/`) — `cargo test --lib` for each crate. kwctl uses `--bins`.
+- `make e2e-tests` (from `crates/`) — The integration and e2e targets of each crate
+- `make coverage` (from `crates/`) — Coverage of the unit tests and of the integration tests
 
 These targets of a single crate are also useful:
 
@@ -53,11 +49,9 @@ These targets of a single crate are also useful:
 
 The workspace has three levels of tests.
 
-| Level             | Command                 | Scope                                            |
-| ----------------- | ----------------------- | ------------------------------------------------ |
-| Unit              | `make unit-tests`       | One module. `cargo test --lib`, or `--bins` for kwctl. |
-| Integration       | `make integration-tests` | The public interface of one crate. `cargo test --test '*'`. |
-| End to end        | `make e2e-tests`        | The full binary, with the network and the registries. |
+- Unit — `make unit-tests` — One module. `cargo test --lib`, or `--bins` for kwctl.
+- Integration — `make integration-tests` — The public interface of one crate. `cargo test --test '*'`.
+- End to end — `make e2e-tests` — The full binary, with the network and the registries.
 
 Some tests need a feature. The sigstore tests need `sigstore-testing`. The
 tracing tests of `policy-server` need `otel_tests`.

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — the Rust workspace
 
-This file applies to all the files in `crates/`. The root
+- This file applies to all the files in `crates/`. The root
 [`AGENTS.md`](../AGENTS.md) holds the rules for the full monorepo.
 
 ## Structure
@@ -11,7 +11,6 @@ This file applies to all the files in `crates/`. The root
 - `policy-fetcher` — Fetches policies from OCI and HTTPS, and verifies signatures
 - `burrego` — Evaluator for Rego (OPA and Gatekeeper)
 - `context-aware-test-policy` — A test fixture. The CI matrix does not include it.
-
 - The Cargo workspace root is the `Cargo.toml` in the root of the repository.
   It declares `members = ["crates/*"]`.
 
@@ -20,7 +19,6 @@ This file applies to all the files in `crates/`. The root
 - The file `crates/Makefile` collects the operations for the full workspace.
 - Each crate also has a `Makefile`. The CI calls those crate Makefiles
   directly.
-
 - `make build` (from `crates/`) — `cargo build --release`
 - `make fmt` (from `crates/`) — `cargo +nightly fmt --all -- --check`
 - `make lint` (from `crates/`) — `cargo clippy --workspace -- -D warnings`
@@ -53,7 +51,6 @@ The workspace has three levels of tests.
 - Unit — `make unit-tests` — One module. `cargo test --lib`, or `--bins` for kwctl.
 - Integration — `make integration-tests` — The public interface of one crate. `cargo test --test '*'`.
 - End to end — `make e2e-tests` — The full binary, with the network and the registries.
-
 - Some tests need a feature. The sigstore tests need `sigstore-testing`. The
   tracing tests of `policy-server` need `otel_tests`.
 - Write the test in the crate that owns the behavior.

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md — the Rust workspace
+
+This file applies to all the files in `crates/`. The root
+[`AGENTS.md`](../AGENTS.md) holds the rules for the full monorepo.
+
+## Structure
+
+| Crate                       | Purpose                                                    |
+| --------------------------- | ---------------------------------------------------------- |
+| `policy-server`             | HTTP server that evaluates WebAssembly admission policies   |
+| `kwctl`                     | CLI that pulls, runs, verifies, inspects and annotates policies |
+| `policy-evaluator`          | Engine that evaluates policies (Wasm and Rego)              |
+| `policy-fetcher`            | Fetches policies from OCI and HTTPS, and verifies signatures |
+| `burrego`                   | Evaluator for Rego (OPA and Gatekeeper)                     |
+| `context-aware-test-policy` | A test fixture. The CI matrix does not include it.          |
+
+The Cargo workspace root is the `Cargo.toml` in the root of the repository. It
+declares `members = ["crates/*"]`.
+
+## Commands
+
+The file `crates/Makefile` collects the operations for the full workspace. Each
+crate also has a `Makefile`. The CI calls those crate Makefiles directly.
+
+| Command (from `crates/`)   | Effect                                                        |
+| -------------------------- | ------------------------------------------------------------- |
+| `make build`               | `cargo build --release`                                       |
+| `make fmt`                 | `cargo +nightly fmt --all -- --check`                          |
+| `make lint`                | `cargo clippy --workspace -- -D warnings`                      |
+| `make lint-fix`            | `cargo clippy --workspace --fix --allow-dirty --allow-staged`  |
+| `make check`               | `cargo check --workspace`                                      |
+| `make test`                | The `test` target of each crate. Each one first runs fmt and lint. |
+| `make unit-tests`          | `cargo test --lib` for each crate. kwctl uses `--bins`.        |
+| `make e2e-tests`           | The integration and e2e targets of each crate                  |
+| `make coverage`            | Coverage of the unit tests and of the integration tests        |
+
+These targets of a single crate are also useful:
+
+- `crates/policy-server`: `make integration-tests` runs `cargo test --test '*'`
+  and `cargo test --features otel_tests -- test_otel`. `make e2e-tests-sigstore`
+  needs the feature `sigstore-testing`. `make build-docs` writes `cli-docs.adoc`
+  again.
+- `crates/kwctl`: `make e2e-tests`, `make e2e-tests-sigstore` and
+  `make build-docs`.
+- `crates/policy-evaluator`: the integration tests need the file
+  `annotated-policy.wasm`. The Makefile builds `context-aware-test-policy` for
+  the target `wasm32-wasip1`, then annotates it with `kwctl`. Thus `kwctl` must
+  be in your `PATH`. Build `kwctl` first.
+- `crates/burrego`: `make e2e-tests` goes through `test_data/*`. It needs `opa`
+  and `bats`.
+
+## Testing strategy
+
+The workspace has three levels of tests.
+
+| Level             | Command                 | Scope                                            |
+| ----------------- | ----------------------- | ------------------------------------------------ |
+| Unit              | `make unit-tests`       | One module. `cargo test --lib`, or `--bins` for kwctl. |
+| Integration       | `make integration-tests` | The public interface of one crate. `cargo test --test '*'`. |
+| End to end        | `make e2e-tests`        | The full binary, with the network and the registries. |
+
+Some tests need a feature. The sigstore tests need `sigstore-testing`. The
+tracing tests of `policy-server` need `otel_tests`.
+
+Write the test in the crate that owns the behavior.
+
+## Development principles
+
+- The evaluation logic lives in `policy-evaluator`. `policy-server` and `kwctl`
+  are thin layers over it. When a fix belongs to both binaries, it belongs to
+  the library.
+- `policy-fetcher` owns the access to the network and the verification of the
+  signatures. The other crates do not open connections to a registry.
+- A new crate needs a reason. Prefer a module in a crate that exists.
+- An error that reaches the user must say which policy failed and why.
+
+## Pitfalls
+
+- `policy-server` and `kwctl` both use `policy-evaluator`. A change there has an
+  effect on both binaries. Test both.
+- The files `cli-docs.adoc` come from the definitions of the CLI. A new flag or
+  a new subcommand makes them old.
+- The workspace has one `Cargo.lock`. A new version of a dependency reaches
+  every crate.
+
+## Code conventions
+
+- Obey the standard conventions of `rustfmt`.
+- Prefer `to_owned` to convert a `&str` into a `String`.
+- Write `anyhow::Result` in full. Do not write `use anyhow::Result`.
+- In a binary, return most errors as `anyhow::Result`. Do not inspect errors
+  outside the tests and the top-level error handler.
+- In a binary or a library, build most errors from an `enum` that derives
+  `thiserror`. Do not use a raw `anyhow!`.
+- Prefer `use crate::foo::bar` to `use super::bar` or `use crate::foo::*`. Test
+  modules are the exception. They often start with `use super::*`.
+- Prefer `expect` to `unwrap`. Give the reason why the operation cannot fail. If
+  the assumption is wrong one day, the message helps the person who debugs it.
+
+These conventions apply to the test code:
+
+- Prefer `assert_eq!(a, b)` to `assert!(a == b)` or `assert!(a.eq(&b))`.
+- Prefer a test that returns nothing to a test that returns
+  `Result<(), Error>`. This removes the final `Ok(())` and the extra import.
+- Use a table test with [`rstest`](https://docs.rs/rstest/) when the cases are
+  similar but the inputs are different.
+- Use [`mockall`](https://docs.rs/mockall/) and
+  [`mockall_double`](https://docs.rs/mockall_double/) to mock structs and traits.
+- Do not write a trait that exists only for the tests.
+- All the code must be well tested and easy to read.

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — the Rust workspace
 
 - This file applies to all the files in `crates/`. The root
-[`AGENTS.md`](../AGENTS.md) holds the rules for the full monorepo.
+  [`AGENTS.md`](../AGENTS.md) holds the rules for the full monorepo.
 
 ## Structure
 
@@ -11,6 +11,7 @@
 - `policy-fetcher` — Fetches policies from OCI and HTTPS, and verifies signatures
 - `burrego` — Evaluator for Rego (OPA and Gatekeeper)
 - `context-aware-test-policy` — A test fixture. The CI matrix does not include it.
+
 - The Cargo workspace root is the `Cargo.toml` in the root of the repository.
   It declares `members = ["crates/*"]`.
 
@@ -19,6 +20,7 @@
 - The file `crates/Makefile` collects the operations for the full workspace.
 - Each crate also has a `Makefile`. The CI calls those crate Makefiles
   directly.
+
 - `make build` (from `crates/`) — `cargo build --release`
 - `make fmt` (from `crates/`) — `cargo +nightly fmt --all -- --check`
 - `make lint` (from `crates/`) — `cargo clippy --workspace -- -D warnings`
@@ -51,6 +53,7 @@ The workspace has three levels of tests.
 - Unit — `make unit-tests` — One module. `cargo test --lib`, or `--bins` for kwctl.
 - Integration — `make integration-tests` — The public interface of one crate. `cargo test --test '*'`.
 - End to end — `make e2e-tests` — The full binary, with the network and the registries.
+
 - Some tests need a feature. The sigstore tests need `sigstore-testing`. The
   tracing tests of `policy-server` need `otel_tests`.
 - Write the test in the crate that owns the behavior.

--- a/internal/controller/AGENTS.md
+++ b/internal/controller/AGENTS.md
@@ -1,22 +1,22 @@
 # AGENTS.md — the controller
 
 - This file applies to all the files in `internal/controller/`. The root
-[`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+  [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
 
 ## Structure
 
 - This package holds the reconcilers for the CRDs of the group
-`policies.kubewarden.io`. They are built on controller-runtime.
+  `policies.kubewarden.io`. They are built on controller-runtime.
 - `admissionpolicy_controller.go`, `clusteradmissionpolicy_controller.go` and
-the two `*group` files reconcile the policies into webhook configurations.
+  the two `*group` files reconcile the policies into webhook configurations.
 - `policyserver_controller.go` and the `policy_server_*.go` files handle the
-deployment, the service, the configmap, the PDB and the certificate secret of a
-`PolicyServer`.
+  deployment, the service, the configmap, the PDB and the certificate secret
+  of a `PolicyServer`.
 - `cert_controller.go` rotates the CA and the serving certificates.
 - `policy_subreconciler.go` and `policy_subreconciler_webhook.go` hold the
-logic that the four policy kinds share.
+  logic that the four policy kinds share.
 - `legacy_policy_migration.go` migrates away from the deprecated package
-`api/policies/v1alpha2`.
+  `api/policies/v1alpha2`.
 - `suite_test.go` starts envtest for the full package.
 
 ## Testing strategy
@@ -25,6 +25,7 @@ logic that the four policy kinds share.
 - They are the integration level of the project.
 - Use them for the behavior of a reconciler.
 - For logic that needs no API server, write a unit test instead.
+
 - Run `make test-go` from the root of the repository.
 - The Makefile downloads the envtest binaries into `.envtest/` and sets
   `KUBEBUILDER_ASSETS`.

--- a/internal/controller/AGENTS.md
+++ b/internal/controller/AGENTS.md
@@ -9,7 +9,7 @@
   `policies.kubewarden.io`. They are built on controller-runtime.
 - `admissionpolicy_controller.go`, `clusteradmissionpolicy_controller.go` and
   the two `*group` files reconcile the policies into webhook configurations.
-- `policyserver_controller.go` and the `policy_server_*.go` files handle the
+- `policyserver_controller.go` and the `policyserver_controller_*.go` files handle the
   deployment, the service, the configmap, the PDB and the certificate secret
   of a `PolicyServer`.
 - `cert_controller.go` rotates the CA and the serving certificates.

--- a/internal/controller/AGENTS.md
+++ b/internal/controller/AGENTS.md
@@ -1,33 +1,30 @@
 # AGENTS.md — the controller
 
-This file applies to all the files in `internal/controller/`. The root
+- This file applies to all the files in `internal/controller/`. The root
 [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
 
 ## Structure
 
-This package holds the reconcilers for the CRDs of the group
+- This package holds the reconcilers for the CRDs of the group
 `policies.kubewarden.io`. They are built on controller-runtime.
-
-- `admissionpolicy_controller.go`, `clusteradmissionpolicy_controller.go` and the
-  two `*group` files reconcile the policies into webhook configurations.
+- `admissionpolicy_controller.go`, `clusteradmissionpolicy_controller.go` and
+the two `*group` files reconcile the policies into webhook configurations.
 - `policyserver_controller.go` and the `policy_server_*.go` files handle the
-  deployment, the service, the configmap, the PDB and the certificate secret of a
-  `PolicyServer`.
+deployment, the service, the configmap, the PDB and the certificate secret of a
+`PolicyServer`.
 - `cert_controller.go` rotates the CA and the serving certificates.
-- `policy_subreconciler.go` and `policy_subreconciler_webhook.go` hold the logic
-  that the four policy kinds share.
+- `policy_subreconciler.go` and `policy_subreconciler_webhook.go` hold the
+logic that the four policy kinds share.
 - `legacy_policy_migration.go` migrates away from the deprecated package
-  `api/policies/v1alpha2`.
+`api/policies/v1alpha2`.
 - `suite_test.go` starts envtest for the full package.
 
 ## Testing strategy
 
-The tests of this package run against a real API server with envtest.
-
+- The tests of this package run against a real API server with envtest.
 - They are the integration level of the project.
 - Use them for the behavior of a reconciler.
 - For logic that needs no API server, write a unit test instead.
-
 - Run `make test-go` from the root of the repository.
 - The Makefile downloads the envtest binaries into `.envtest/` and sets
   `KUBEBUILDER_ASSETS`.

--- a/internal/controller/AGENTS.md
+++ b/internal/controller/AGENTS.md
@@ -22,16 +22,15 @@ This package holds the reconcilers for the CRDs of the group
 
 ## Testing strategy
 
-The tests of this package run against a real API server with envtest. They are
-the integration level of the project. Use them for the behavior of a reconciler.
-For logic that needs no API server, write a unit test instead.
+The tests of this package run against a real API server with envtest.
 
-```sh
-make test-go
-```
+- They are the integration level of the project.
+- Use them for the behavior of a reconciler.
+- For logic that needs no API server, write a unit test instead.
 
-Run this command from the root of the repository. The Makefile downloads the
-envtest binaries into `.envtest/` and sets `KUBEBUILDER_ASSETS`.
+- Run `make test-go` from the root of the repository.
+- The Makefile downloads the envtest binaries into `.envtest/` and sets
+  `KUBEBUILDER_ASSETS`.
 
 These facts apply to the suite:
 

--- a/internal/controller/AGENTS.md
+++ b/internal/controller/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — the controller
+
+This file applies to all the files in `internal/controller/`. The root
+[`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+
+## Structure
+
+This package holds the reconcilers for the CRDs of the group
+`policies.kubewarden.io`. They are built on controller-runtime.
+
+- `admissionpolicy_controller.go`, `clusteradmissionpolicy_controller.go` and the
+  two `*group` files reconcile the policies into webhook configurations.
+- `policyserver_controller.go` and the `policy_server_*.go` files handle the
+  deployment, the service, the configmap, the PDB and the certificate secret of a
+  `PolicyServer`.
+- `cert_controller.go` rotates the CA and the serving certificates.
+- `policy_subreconciler.go` and `policy_subreconciler_webhook.go` hold the logic
+  that the four policy kinds share.
+- `legacy_policy_migration.go` migrates away from the deprecated package
+  `api/policies/v1alpha2`.
+- `suite_test.go` starts envtest for the full package.
+
+## Testing strategy
+
+The tests of this package run against a real API server with envtest. They are
+the integration level of the project. Use them for the behavior of a reconciler.
+For logic that needs no API server, write a unit test instead.
+
+```sh
+make test-go
+```
+
+Run this command from the root of the repository. The Makefile downloads the
+envtest binaries into `.envtest/` and sets `KUBEBUILDER_ASSETS`.
+
+These facts apply to the suite:
+
+- The suite uses Ginkgo v2, Gomega and `SynchronizedBeforeSuite`. All the specs
+  are in one package.
+- The suite loads the CRDs from the Helm chart. The function
+  `kubewardenCRDPaths()` in `suite_test.go` lists the five files
+  `policies.kubewarden.io_*.yaml` in
+  `charts/admission-controller/templates/crds/`. It excludes the CRDs of the
+  policy reports, because their Helm conditionals are not plain YAML.
+- If you add a CRD kind, add its path in the chart to `kubewardenCRDPaths()`.
+- The constants are the namespace `kubewarden-integration-tests`,
+  `timeout = 180s`, `pollInterval = 250ms` and `consistencyTimeout = 5s`. Use
+  `Eventually` with these values. Do not invent new ones. Use `Consistently` to
+  assert that nothing happens.
+- To work on one spec, use the focus helpers of Ginkgo: `FIt`, `FDescribe` and
+  `FContext`. Never commit them. A focused suite gives a false pass.
+
+## Development principles
+
+- A reconciler must be idempotent. The same input gives the same result, and a
+  second call changes nothing.
+- A reconciler must converge from any state. Read the state of the cluster.
+  Do not assume the result of the previous call.
+- Keep the RBAC markers as narrow as the reconciler needs.
+- Logic that the four policy kinds share belongs in `policy_subreconciler.go`.
+
+## Pitfalls
+
+- The `+kubebuilder:rbac:` markers in this package generate
+  `charts/admission-controller/templates/controller/controller-rbac-roles.yaml`.
+  After you add a permission or make one wider, run `make generate` and
+  `make check-generate`.
+- After a change to a CRD, run `make manifests` before the tests. If you do not,
+  the suite runs against an old schema.
+- Keep the markers `//+kubebuilder:scaffold:imports` and
+  `//+kubebuilder:scaffold:scheme`. The Kubebuilder scaffolding inserts code at
+  these positions.
+- The file `.golangci.yml` is strict for this package. The test files have
+  exclusions. The production code has none.


### PR DESCRIPTION
## Description

Add a root AGENTS.md and three nested files for the Rust workspace, the Helm chart and the controller package. They record the build, test and lint commands, the generated artifacts that must be refreshed with make generate, and the commit rules of the project.

The files also carry the Kubewarden AI policy. Contributors stay accountable for the changes, and every AI-assisted commit needs an Assisted-by trailer.