### PR TITLE
ci: stop using CODECOV_ORG_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,13 +142,12 @@ jobs:
       - run: make test-go
       - name: Upload Go test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }} # zizmor: ignore[secrets-outside-env]
         with:
           name: go-tests
           files: coverage/cover.out
           flags: go-tests
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   e2e-go:
     name: Go e2e tests
@@ -372,13 +371,12 @@ jobs:
       - run: cargo llvm-cov --ignore-run-fail --lcov --output-path coverage/rust/lcov.info
       - name: Upload Rust test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }} # zizmor: ignore[secrets-outside-env]
         with:
           name: rust-tests
           files: coverage/rust/lcov.info
           flags: rust-tests
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   build-kwctl:
     name: Build kwctl


### PR DESCRIPTION
Switch to the standard name of the token, CODECOV_TOKEN.

Adapt the actions following the instructions from

https://docs.codecov.com/docs/codecov-tokens#example-github-actions--official-codecov-action
