### PR TITLE
fix: move agents.md to the chart directory

### DIFF
--- a/charts/AGENTS.md
+++ b/charts/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — the Helm chart
 
 - This file applies to all the files in `charts/admission-controller/`. The
-  root [`AGENTS.md`](../../AGENTS.md) holds the rules for the full monorepo.
+  root [`AGENTS.md`](../AGENTS.md) holds the rules for the full monorepo.
 - This is the single unified chart. It installs the controller, the audit
   scanner and the defaults of the policy server.
 


### PR DESCRIPTION
## Description

To avoid the AGENTS.md file being copied to the helm-chart repository, the file has been moved to the chart directory. Therefore, it's ignored by the automation when coping the content of the admission-controller chart directory into the helm-chart repo.
