### PR TITLE
ci: prevent concurrent container builds from racing on :latest

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,15 +1,14 @@
 name: Build, Sign, and Generate SBOM, Attestation & Provenance
 
 on:
-  workflow_call:
-    inputs:
-      version:
-        type: string
-
   push:
     branches:
       - "main"
       - "feat-**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -61,12 +60,6 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/feat') }}
         run: |
           echo "TAG_NAME=latest-$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-      - name: Retrieve tag name (release)
-        if: ${{ !startsWith(github.ref, 'refs/heads/') }}
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          echo TAG_NAME=$INPUT_VERSION >> $GITHUB_ENV
       - name: Merge multi-arch images
         uses: kubewarden/github-actions/merge-multiarch@143b9e4b11ddc47370482267383586e6f1bc7efe # v7.0.1
         with:


### PR DESCRIPTION
## Description

Multiple pushes to the same branch in quick succession start overlapping build-containers runs. Since these runs are not serialized, a run started from an older commit can finish after a run started from a newer commit, overwriting the :latest (or latest-<branch>) tag with an image built from a stale commit.

Add a concurrency group so a new push cancels any in-progress run for the same ref. Replace the unused workflow_call trigger, which nothing invokes (release.yml duplicates these jobs inline instead of calling this workflow), with workflow_dispatch so the build can be re-triggered manually, and drop the release tag-name step that becomes unreachable without workflow_call.

